### PR TITLE
Remove dependency on es6-promise, which can conflict with consumer Pr…

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -24,8 +24,5 @@
     "mocha": "^3.1.2",
     "tslint": "^3.15.1",
     "typescript": "^2.0.9"
-  },
-  "dependencies": {
-    "@types/es6-promise": "0.0.32"
   }
 }

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -6,7 +6,8 @@
     "noImplicitReturns": true,
     "newLine": "LF",
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "lib": [ "es2015.promise", "es5" ]
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
…omise definitions

@ejball Currently, if a consumer has their own definition for `Promise`, you get errors relating to `error TS2300L: Duplicate identifier 'Promise'`. I'm not sure what the best solution is to this problem, but it probably seems better for clients to provide their own definition (and implementation) of `Promise`?