### PR TITLE
Update return type of IFetchResponse.headers.get to allow null

### DIFF
--- a/ts/src/facilityCore.ts
+++ b/ts/src/facilityCore.ts
@@ -49,7 +49,7 @@ export namespace HttpClientUtility {
 	export interface IFetchResponse {
 		status: number;
 		headers: {
-			get(name: string): string;
+			get(name: string): string | null;
 		};
 		json(): Promise<any>;
 	}


### PR DESCRIPTION
The DOM types for window.fetch specify that headers may return null, making the current Facility typings produce an error when using `strictNullChecks: true`.