### PR TITLE
Build on unix, update to Cake 0.25.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - "6"
 script:
-  - ./build.sh
+  - ./build-js.sh

--- a/build-js.sh
+++ b/build-js.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+pushd ts >/dev/null
+npm install
+npm run test
+popd >/dev/null
+
+pushd example/js >/dev/null
+npm install
+npm run test
+popd >/dev/null
+
+pushd example/ts >/dev/null
+npm install
+npm run test
+popd >/dev/null

--- a/build.cake
+++ b/build.cake
@@ -151,10 +151,11 @@ Task("Coverage")
 
 		string filter = string.Concat(coverageAssemblies.Select(x => $@" ""-filter:+[{x}]*"""));
 
+		var nunitPath = Context.Tools.Resolve("nunit3-console.exe").ToString();
 		foreach (var testDllPath in GetFiles($"tests/**/bin/**/*.UnitTests.dll"))
 		{
-			ExecuteProcess(@"cake\OpenCover\tools\OpenCover.Console.exe",
-				$@"-register:user -mergeoutput ""-target:cake\NUnit.ConsoleRunner\tools\nunit3-console.exe"" ""-targetargs:{testDllPath} --noresult"" ""-output:release\coverage.xml"" -skipautoprops -returntargetcode" + filter);
+			ExecuteTool("OpenCover.Console.exe",
+				$@"-register:user -mergeoutput ""-target:{nunitPath}"" ""-targetargs:{testDllPath} --noresult"" ""-output:{File("release/coverage.xml")}"" -skipautoprops -returntargetcode" + filter);
 		}
 	});
 
@@ -162,14 +163,14 @@ Task("CoverageReport")
 	.IsDependentOn("Coverage")
 	.Does(() =>
 	{
-		ExecuteProcess(@"cake\ReportGenerator\tools\ReportGenerator.exe", $@"""-reports:release\coverage.xml"" ""-targetdir:release\coverage""");
+		ExecuteTool("ReportGenerator.exe", $@"""-reports:{File("release/coverage.xml")}"" ""-targetdir:{File("release/coverage")}""");
 	});
 
 Task("CoveragePublish")
 	.IsDependentOn("Coverage")
 	.Does(() =>
 	{
-		ExecuteProcess(@"cake\coveralls.io\tools\coveralls.net.exe", $@"--opencover ""release\coverage.xml"" --full-sources --repo-token {coverallsApiKey}");
+		ExecuteTool("coveralls.net.exe", $@"--opencover ""{File("release/coverage.xml")}"" --full-sources --repo-token {coverallsApiKey}");
 	});
 
 Task("Default")
@@ -204,6 +205,11 @@ void ExecuteCodeGen(string args, bool verify)
 		throw new InvalidOperationException("Generated code doesn't match; use -target=CodeGen to regenerate.");
 	else if (exitCode != 0)
 		throw new InvalidOperationException($"Code generation failed with exit code {exitCode}.");
+}
+
+void ExecuteTool(string tool, string arguments)
+{
+	ExecuteProcess(Context.Tools.Resolve(tool).ToString(), arguments);
 }
 
 void ExecuteProcess(string exePath, string arguments)

--- a/build.ps1
+++ b/build.ps1
@@ -25,7 +25,7 @@ If (!(Test-Path $PackagesConfigPath)) {
     [System.IO.File]::WriteAllLines($PackagesConfigPath, @(
         "<?xml version=`"1.0`" encoding=`"utf-8`"?>",
         "<packages>",
-        "`t<package id=`"Cake`" version=`"0.17.0`" />",
+        "`t<package id=`"Cake`" version=`"0.25.0`" />",
         "</packages>"))
 }
 

--- a/build.sh
+++ b/build.sh
@@ -1,17 +1,63 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+##########################################################################
+# This is the Cake bootstrapper script for Linux and OS X.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
 
-pushd ts >/dev/null
-npm install
-npm run test
-popd >/dev/null
+# Define directories.
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+TOOLS_DIR=$SCRIPT_DIR/cake
+NUGET_EXE=$TOOLS_DIR/nuget.exe
+NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+CAKE_VERSION=0.25.0
+CAKE_EXE=$TOOLS_DIR/Cake.$CAKE_VERSION/Cake.exe
 
-pushd example/js >/dev/null
-npm install
-npm run test
-popd >/dev/null
+# Define default arguments.
+SCRIPT_ARGUMENTS=$@
 
-pushd example/ts >/dev/null
-npm install
-npm run test
-popd >/dev/null
+# Make sure the tools folder exist.
+if [ ! -d "$TOOLS_DIR" ]; then
+  mkdir "$TOOLS_DIR"
+fi
+
+###########################################################################
+# INSTALL NUGET
+###########################################################################
+
+# Download NuGet if it does not exist.
+if [ ! -f "$NUGET_EXE" ]; then
+    echo "Downloading NuGet..."
+    curl -Lsfo "$NUGET_EXE" $NUGET_URL
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading nuget.exe."
+        exit 1
+    fi
+fi
+
+###########################################################################
+# INSTALL CAKE
+###########################################################################
+
+if [ ! -f "$CAKE_EXE" ]; then
+    mono "$NUGET_EXE" install Cake -Version $CAKE_VERSION -OutputDirectory "$TOOLS_DIR"
+    if [ $? -ne 0 ]; then
+        echo "An error occured while installing Cake."
+        exit 1
+    fi
+fi
+
+# Make sure that Cake has been installed.
+if [ ! -f "$CAKE_EXE" ]; then
+    echo "Could not find Cake.exe at '$CAKE_EXE'."
+    exit 1
+fi
+
+###########################################################################
+# RUN BUILD SCRIPT
+###########################################################################
+
+export MONO_ROOT=$(dirname $(which mono))/../
+
+# Start Cake
+exec mono "$CAKE_EXE" build.cake --paths_tools=cake --experimental ${SCRIPT_ARGUMENTS[@]}


### PR DESCRIPTION
OpenCover only runs on Windows, so the Coverage target will fail on unix.