### PR TITLE
Add request context to server service interface.

### DIFF
--- a/example/js/exampleApiServer.js
+++ b/example/js/exampleApiServer.js
@@ -31,10 +31,12 @@ function parseBoolean(value) {
   return undefined;
 }
 
-export function createApp(service) {
+export function createApp(serviceOrFactory) {
   const app = express();
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));
+
+  const getService = typeof serviceOrFactory === 'function' ? serviceOrFactory : () => serviceOrFactory;
 
   /** Gets widgets. */
   app.get('/widgets', function (req, res, next) {
@@ -58,7 +60,7 @@ export function createApp(service) {
       request.minPrice = parseFloat(req.query['minPrice']);
     }
 
-    return service.getWidgets(request)
+    return getService(req, res).getWidgets(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -87,7 +89,7 @@ export function createApp(service) {
     const request = {};
     request.widget = req.body;
 
-    return service.createWidget(request)
+    return getService(req, res).createWidget(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -111,7 +113,7 @@ export function createApp(service) {
     request.id = req.params.id;
     request.ifNoneMatch = req.header('If-None-Match');
 
-    return service.getWidget(request)
+    return getService(req, res).getWidget(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -141,7 +143,7 @@ export function createApp(service) {
     const request = {};
     request.id = req.params.id;
 
-    return service.deleteWidget(request)
+    return getService(req, res).deleteWidget(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -164,7 +166,7 @@ export function createApp(service) {
     request.ops = req.body.ops;
     request.weight = req.body.weight;
 
-    return service.editWidget(request)
+    return getService(req, res).editWidget(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -191,7 +193,7 @@ export function createApp(service) {
     const request = {};
     request.ids = req.body;
 
-    return service.getWidgetBatch(request)
+    return getService(req, res).getWidgetBatch(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -217,7 +219,7 @@ export function createApp(service) {
     const request = {};
     request.id = req.params.id;
 
-    return service.getWidgetWeight(request)
+    return getService(req, res).getWidgetWeight(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -240,7 +242,7 @@ export function createApp(service) {
     const request = {};
     request.key = req.params.key;
 
-    return service.getPreference(request)
+    return getService(req, res).getPreference(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -264,7 +266,7 @@ export function createApp(service) {
     request.key = req.params.key;
     request.value = req.body;
 
-    return service.setPreference(request)
+    return getService(req, res).setPreference(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -286,7 +288,7 @@ export function createApp(service) {
   app.get('/', function (req, res, next) {
     const request = {};
 
-    return service.getInfo(request)
+    return getService(req, res).getInfo(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -308,7 +310,7 @@ export function createApp(service) {
   app.post('/notRestful', function (req, res, next) {
     const request = {};
 
-    return service.notRestful(request)
+    return getService(req, res).notRestful(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -328,7 +330,7 @@ export function createApp(service) {
     const request = {};
     request.sink = req.body.sink;
 
-    return service.kitchen(request)
+    return getService(req, res).kitchen(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;

--- a/example/js/exampleApiServer.js
+++ b/example/js/exampleApiServer.js
@@ -58,7 +58,7 @@ export function createApp(service) {
       request.minPrice = parseFloat(req.query['minPrice']);
     }
 
-    return service.getWidgets(request, { request: req, response: res })
+    return service.getWidgets(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -87,7 +87,7 @@ export function createApp(service) {
     const request = {};
     request.widget = req.body;
 
-    return service.createWidget(request, { request: req, response: res })
+    return service.createWidget(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -111,7 +111,7 @@ export function createApp(service) {
     request.id = req.params.id;
     request.ifNoneMatch = req.header('If-None-Match');
 
-    return service.getWidget(request, { request: req, response: res })
+    return service.getWidget(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -141,7 +141,7 @@ export function createApp(service) {
     const request = {};
     request.id = req.params.id;
 
-    return service.deleteWidget(request, { request: req, response: res })
+    return service.deleteWidget(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -164,7 +164,7 @@ export function createApp(service) {
     request.ops = req.body.ops;
     request.weight = req.body.weight;
 
-    return service.editWidget(request, { request: req, response: res })
+    return service.editWidget(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -191,7 +191,7 @@ export function createApp(service) {
     const request = {};
     request.ids = req.body;
 
-    return service.getWidgetBatch(request, { request: req, response: res })
+    return service.getWidgetBatch(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -217,7 +217,7 @@ export function createApp(service) {
     const request = {};
     request.id = req.params.id;
 
-    return service.getWidgetWeight(request, { request: req, response: res })
+    return service.getWidgetWeight(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -240,7 +240,7 @@ export function createApp(service) {
     const request = {};
     request.key = req.params.key;
 
-    return service.getPreference(request, { request: req, response: res })
+    return service.getPreference(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -264,7 +264,7 @@ export function createApp(service) {
     request.key = req.params.key;
     request.value = req.body;
 
-    return service.setPreference(request, { request: req, response: res })
+    return service.setPreference(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -286,7 +286,7 @@ export function createApp(service) {
   app.get('/', function (req, res, next) {
     const request = {};
 
-    return service.getInfo(request, { request: req, response: res })
+    return service.getInfo(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -308,7 +308,7 @@ export function createApp(service) {
   app.post('/notRestful', function (req, res, next) {
     const request = {};
 
-    return service.notRestful(request, { request: req, response: res })
+    return service.notRestful(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -328,7 +328,7 @@ export function createApp(service) {
     const request = {};
     request.sink = req.body.sink;
 
-    return service.kitchen(request, { request: req, response: res })
+    return service.kitchen(request)
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;

--- a/example/js/exampleApiServer.js
+++ b/example/js/exampleApiServer.js
@@ -58,7 +58,7 @@ export function createApp(service) {
       request.minPrice = parseFloat(req.query['minPrice']);
     }
 
-    return service.getWidgets(request)
+    return service.getWidgets(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -87,7 +87,7 @@ export function createApp(service) {
     const request = {};
     request.widget = req.body;
 
-    return service.createWidget(request)
+    return service.createWidget(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -111,7 +111,7 @@ export function createApp(service) {
     request.id = req.params.id;
     request.ifNoneMatch = req.header('If-None-Match');
 
-    return service.getWidget(request)
+    return service.getWidget(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -141,7 +141,7 @@ export function createApp(service) {
     const request = {};
     request.id = req.params.id;
 
-    return service.deleteWidget(request)
+    return service.deleteWidget(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -164,7 +164,7 @@ export function createApp(service) {
     request.ops = req.body.ops;
     request.weight = req.body.weight;
 
-    return service.editWidget(request)
+    return service.editWidget(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -191,7 +191,7 @@ export function createApp(service) {
     const request = {};
     request.ids = req.body;
 
-    return service.getWidgetBatch(request)
+    return service.getWidgetBatch(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -217,7 +217,7 @@ export function createApp(service) {
     const request = {};
     request.id = req.params.id;
 
-    return service.getWidgetWeight(request)
+    return service.getWidgetWeight(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -240,7 +240,7 @@ export function createApp(service) {
     const request = {};
     request.key = req.params.key;
 
-    return service.getPreference(request)
+    return service.getPreference(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -264,7 +264,7 @@ export function createApp(service) {
     request.key = req.params.key;
     request.value = req.body;
 
-    return service.setPreference(request)
+    return service.setPreference(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -286,7 +286,7 @@ export function createApp(service) {
   app.get('/', function (req, res, next) {
     const request = {};
 
-    return service.getInfo(request)
+    return service.getInfo(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -308,7 +308,7 @@ export function createApp(service) {
   app.post('/notRestful', function (req, res, next) {
     const request = {};
 
-    return service.notRestful(request)
+    return service.notRestful(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -328,7 +328,7 @@ export function createApp(service) {
     const request = {};
     request.sink = req.body.sink;
 
-    return service.kitchen(request)
+    return service.kitchen(request, { request: req, response: res })
       .then(result => {
         if (result.error) {
           const status = result.error.code && standardErrorCodes[result.error.code] || 500;

--- a/example/ts/src/exampleApiServer.ts
+++ b/example/ts/src/exampleApiServer.ts
@@ -6,6 +6,53 @@ import { IServiceResult, IServiceError } from 'facility-core';
 import { IExampleApi, IGetWidgetsRequest, IGetWidgetsResponse, ICreateWidgetRequest, ICreateWidgetResponse, IGetWidgetRequest, IGetWidgetResponse, IDeleteWidgetRequest, IDeleteWidgetResponse, IEditWidgetRequest, IEditWidgetResponse, IGetWidgetBatchRequest, IGetWidgetBatchResponse, IGetWidgetWeightRequest, IGetWidgetWeightResponse, IGetPreferenceRequest, IGetPreferenceResponse, ISetPreferenceRequest, ISetPreferenceResponse, IGetInfoRequest, IGetInfoResponse, INotRestfulRequest, INotRestfulResponse, IKitchenRequest, IKitchenResponse, IWidget, IWidgetJob, IPreference, IObsoleteData, IKitchenSink } from './exampleApiTypes';
 export * from './exampleApiTypes';
 
+export interface IRequestContext {
+	request: express.Request;
+	response: express.Response;
+}
+
+declare module './exampleApiTypes' {
+	export interface IExampleApi {
+		/** Gets widgets. */
+		getWidgets(request: IGetWidgetsRequest, context?: IRequestContext): Promise<IServiceResult<IGetWidgetsResponse>>;
+
+		/** Creates a new widget. */
+		createWidget(request: ICreateWidgetRequest, context?: IRequestContext): Promise<IServiceResult<ICreateWidgetResponse>>;
+
+		/** Gets the specified widget. */
+		getWidget(request: IGetWidgetRequest, context?: IRequestContext): Promise<IServiceResult<IGetWidgetResponse>>;
+
+		/** Deletes the specified widget. */
+		deleteWidget(request: IDeleteWidgetRequest, context?: IRequestContext): Promise<IServiceResult<IDeleteWidgetResponse>>;
+
+		/** Edits widget. */
+		editWidget(request: IEditWidgetRequest, context?: IRequestContext): Promise<IServiceResult<IEditWidgetResponse>>;
+
+		/** Gets the specified widgets. */
+		getWidgetBatch(request: IGetWidgetBatchRequest, context?: IRequestContext): Promise<IServiceResult<IGetWidgetBatchResponse>>;
+
+		/**
+		 * Gets the widget weight.
+		 * @deprecated
+		 */
+		getWidgetWeight(request: IGetWidgetWeightRequest, context?: IRequestContext): Promise<IServiceResult<IGetWidgetWeightResponse>>;
+
+		/** Gets a widget preference. */
+		getPreference(request: IGetPreferenceRequest, context?: IRequestContext): Promise<IServiceResult<IGetPreferenceResponse>>;
+
+		/** Sets a widget preference. */
+		setPreference(request: ISetPreferenceRequest, context?: IRequestContext): Promise<IServiceResult<ISetPreferenceResponse>>;
+
+		/** Gets service info. */
+		getInfo(request: IGetInfoRequest, context?: IRequestContext): Promise<IServiceResult<IGetInfoResponse>>;
+
+		/** Demonstrates the default HTTP behavior. */
+		notRestful(request: INotRestfulRequest, context?: IRequestContext): Promise<IServiceResult<INotRestfulResponse>>;
+
+		kitchen(request: IKitchenRequest, context?: IRequestContext): Promise<IServiceResult<IKitchenResponse>>;
+	}
+}
+
 const standardErrorCodes: { [code: string]: number } = {
 	'notModified': 304,
 	'invalidRequest': 400,
@@ -59,7 +106,7 @@ export function createApp(service: IExampleApi): express.Application {
 			request.minPrice = parseFloat(req.query['minPrice']);
 		}
 
-		return service.getWidgets(request)
+		return service.getWidgets(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -88,7 +135,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: ICreateWidgetRequest = {};
 		request.widget = req.body;
 
-		return service.createWidget(request)
+		return service.createWidget(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -112,7 +159,7 @@ export function createApp(service: IExampleApi): express.Application {
 		request.id = req.params.id;
 		request.ifNoneMatch = req.header('If-None-Match');
 
-		return service.getWidget(request)
+		return service.getWidget(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -142,7 +189,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IDeleteWidgetRequest = {};
 		request.id = req.params.id;
 
-		return service.deleteWidget(request)
+		return service.deleteWidget(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -165,7 +212,7 @@ export function createApp(service: IExampleApi): express.Application {
 		request.ops = req.body.ops;
 		request.weight = req.body.weight;
 
-		return service.editWidget(request)
+		return service.editWidget(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -192,7 +239,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IGetWidgetBatchRequest = {};
 		request.ids = req.body;
 
-		return service.getWidgetBatch(request)
+		return service.getWidgetBatch(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -218,7 +265,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IGetWidgetWeightRequest = {};
 		request.id = req.params.id;
 
-		return service.getWidgetWeight(request)
+		return service.getWidgetWeight(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -241,7 +288,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IGetPreferenceRequest = {};
 		request.key = req.params.key;
 
-		return service.getPreference(request)
+		return service.getPreference(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -265,7 +312,7 @@ export function createApp(service: IExampleApi): express.Application {
 		request.key = req.params.key;
 		request.value = req.body;
 
-		return service.setPreference(request)
+		return service.setPreference(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -287,7 +334,7 @@ export function createApp(service: IExampleApi): express.Application {
 	app.get('/', function (req, res, next) {
 		const request: IGetInfoRequest = {};
 
-		return service.getInfo(request)
+		return service.getInfo(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -309,7 +356,7 @@ export function createApp(service: IExampleApi): express.Application {
 	app.post('/notRestful', function (req, res, next) {
 		const request: INotRestfulRequest = {};
 
-		return service.notRestful(request)
+		return service.notRestful(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -329,7 +376,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IKitchenRequest = {};
 		request.sink = req.body.sink;
 
-		return service.kitchen(request)
+		return service.kitchen(request, { request: req, response: res })
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;

--- a/example/ts/src/exampleApiServer.ts
+++ b/example/ts/src/exampleApiServer.ts
@@ -6,53 +6,6 @@ import { IServiceResult, IServiceError } from 'facility-core';
 import { IExampleApi, IGetWidgetsRequest, IGetWidgetsResponse, ICreateWidgetRequest, ICreateWidgetResponse, IGetWidgetRequest, IGetWidgetResponse, IDeleteWidgetRequest, IDeleteWidgetResponse, IEditWidgetRequest, IEditWidgetResponse, IGetWidgetBatchRequest, IGetWidgetBatchResponse, IGetWidgetWeightRequest, IGetWidgetWeightResponse, IGetPreferenceRequest, IGetPreferenceResponse, ISetPreferenceRequest, ISetPreferenceResponse, IGetInfoRequest, IGetInfoResponse, INotRestfulRequest, INotRestfulResponse, IKitchenRequest, IKitchenResponse, IWidget, IWidgetJob, IPreference, IObsoleteData, IKitchenSink } from './exampleApiTypes';
 export * from './exampleApiTypes';
 
-export interface IRequestContext {
-	request: express.Request;
-	response: express.Response;
-}
-
-declare module './exampleApiTypes' {
-	export interface IExampleApi {
-		/** Gets widgets. */
-		getWidgets(request: IGetWidgetsRequest, context?: IRequestContext): Promise<IServiceResult<IGetWidgetsResponse>>;
-
-		/** Creates a new widget. */
-		createWidget(request: ICreateWidgetRequest, context?: IRequestContext): Promise<IServiceResult<ICreateWidgetResponse>>;
-
-		/** Gets the specified widget. */
-		getWidget(request: IGetWidgetRequest, context?: IRequestContext): Promise<IServiceResult<IGetWidgetResponse>>;
-
-		/** Deletes the specified widget. */
-		deleteWidget(request: IDeleteWidgetRequest, context?: IRequestContext): Promise<IServiceResult<IDeleteWidgetResponse>>;
-
-		/** Edits widget. */
-		editWidget(request: IEditWidgetRequest, context?: IRequestContext): Promise<IServiceResult<IEditWidgetResponse>>;
-
-		/** Gets the specified widgets. */
-		getWidgetBatch(request: IGetWidgetBatchRequest, context?: IRequestContext): Promise<IServiceResult<IGetWidgetBatchResponse>>;
-
-		/**
-		 * Gets the widget weight.
-		 * @deprecated
-		 */
-		getWidgetWeight(request: IGetWidgetWeightRequest, context?: IRequestContext): Promise<IServiceResult<IGetWidgetWeightResponse>>;
-
-		/** Gets a widget preference. */
-		getPreference(request: IGetPreferenceRequest, context?: IRequestContext): Promise<IServiceResult<IGetPreferenceResponse>>;
-
-		/** Sets a widget preference. */
-		setPreference(request: ISetPreferenceRequest, context?: IRequestContext): Promise<IServiceResult<ISetPreferenceResponse>>;
-
-		/** Gets service info. */
-		getInfo(request: IGetInfoRequest, context?: IRequestContext): Promise<IServiceResult<IGetInfoResponse>>;
-
-		/** Demonstrates the default HTTP behavior. */
-		notRestful(request: INotRestfulRequest, context?: IRequestContext): Promise<IServiceResult<INotRestfulResponse>>;
-
-		kitchen(request: IKitchenRequest, context?: IRequestContext): Promise<IServiceResult<IKitchenResponse>>;
-	}
-}
-
 const standardErrorCodes: { [code: string]: number } = {
 	'notModified': 304,
 	'invalidRequest': 400,
@@ -106,7 +59,7 @@ export function createApp(service: IExampleApi): express.Application {
 			request.minPrice = parseFloat(req.query['minPrice']);
 		}
 
-		return service.getWidgets(request, { request: req, response: res })
+		return service.getWidgets(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -135,7 +88,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: ICreateWidgetRequest = {};
 		request.widget = req.body;
 
-		return service.createWidget(request, { request: req, response: res })
+		return service.createWidget(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -159,7 +112,7 @@ export function createApp(service: IExampleApi): express.Application {
 		request.id = req.params.id;
 		request.ifNoneMatch = req.header('If-None-Match');
 
-		return service.getWidget(request, { request: req, response: res })
+		return service.getWidget(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -189,7 +142,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IDeleteWidgetRequest = {};
 		request.id = req.params.id;
 
-		return service.deleteWidget(request, { request: req, response: res })
+		return service.deleteWidget(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -212,7 +165,7 @@ export function createApp(service: IExampleApi): express.Application {
 		request.ops = req.body.ops;
 		request.weight = req.body.weight;
 
-		return service.editWidget(request, { request: req, response: res })
+		return service.editWidget(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -239,7 +192,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IGetWidgetBatchRequest = {};
 		request.ids = req.body;
 
-		return service.getWidgetBatch(request, { request: req, response: res })
+		return service.getWidgetBatch(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -265,7 +218,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IGetWidgetWeightRequest = {};
 		request.id = req.params.id;
 
-		return service.getWidgetWeight(request, { request: req, response: res })
+		return service.getWidgetWeight(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -288,7 +241,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IGetPreferenceRequest = {};
 		request.key = req.params.key;
 
-		return service.getPreference(request, { request: req, response: res })
+		return service.getPreference(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -312,7 +265,7 @@ export function createApp(service: IExampleApi): express.Application {
 		request.key = req.params.key;
 		request.value = req.body;
 
-		return service.setPreference(request, { request: req, response: res })
+		return service.setPreference(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -334,7 +287,7 @@ export function createApp(service: IExampleApi): express.Application {
 	app.get('/', function (req, res, next) {
 		const request: IGetInfoRequest = {};
 
-		return service.getInfo(request, { request: req, response: res })
+		return service.getInfo(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -356,7 +309,7 @@ export function createApp(service: IExampleApi): express.Application {
 	app.post('/notRestful', function (req, res, next) {
 		const request: INotRestfulRequest = {};
 
-		return service.notRestful(request, { request: req, response: res })
+		return service.notRestful(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;
@@ -376,7 +329,7 @@ export function createApp(service: IExampleApi): express.Application {
 		const request: IKitchenRequest = {};
 		request.sink = req.body.sink;
 
-		return service.kitchen(request, { request: req, response: res })
+		return service.kitchen(request)
 			.then(result => {
 				if (result.error) {
 					const status = result.error.code && standardErrorCodes[result.error.code] || 500;

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -307,30 +307,6 @@ namespace Facility.CodeGen.JavaScript
 						code.WriteLine($"export * from './{Uncapitalize(moduleName)}Types';");
 					}
 
-					if (TypeScript)
-					{
-						code.WriteLine();
-						using (code.Block("export interface IRequestContext {", "}"))
-						{
-							code.WriteLine("request: express.Request;");
-							code.WriteLine("response: express.Response;");
-						}
-
-						code.WriteLine();
-						using (code.Block($"declare module './{Uncapitalize(moduleName)}Types' {{", "}"))
-						using (code.Block($"export interface I{capModuleName} {{", "}"))
-						{
-							foreach (var httpMethodInfo in httpServiceInfo.Methods)
-							{
-								string methodName = httpMethodInfo.ServiceMethod.Name;
-								string capMethodName = CodeGenUtility.Capitalize(methodName);
-								code.WriteLineSkipOnce();
-								WriteJsDoc(code, httpMethodInfo.ServiceMethod);
-								code.WriteLine($"{methodName}(request: I{capMethodName}Request, context?: IRequestContext): Promise<IServiceResult<I{capMethodName}Response>>;");
-							}
-						}
-					}
-
 					// TODO: export this from facility-core
 					code.WriteLine();
 					using (code.Block("const standardErrorCodes" + IfTypeScript(": { [code: string]: number }") + " = {", "};"))
@@ -409,7 +385,7 @@ namespace Facility.CodeGen.JavaScript
 								}
 
 								code.WriteLine();
-								code.WriteLine($"return service.{methodName}(request, {{ request: req, response: res }})");
+								code.WriteLine($"return service.{methodName}(request)");
 
 								using (code.Indent())
 								{

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -305,6 +305,8 @@ namespace Facility.CodeGen.JavaScript
 					{
 						code.WriteLine($"import {{ {string.Join(", ", typeNames)} }} from './{Uncapitalize(moduleName)}Types';");
 						code.WriteLine($"export * from './{Uncapitalize(moduleName)}Types';");
+						code.WriteLine();
+						code.WriteLine("type ServiceFactory<TService> = (req: express.Request, res: express.Response) => TService;");
 					}
 
 					// TODO: export this from facility-core
@@ -338,11 +340,14 @@ namespace Facility.CodeGen.JavaScript
 					}
 
 					code.WriteLine();
-					using (code.Block("export function createApp(service" + IfTypeScript($": I{capModuleName}") + ")" + IfTypeScript(": express.Application") + " {", "}"))
+					using (code.Block("export function createApp(serviceOrFactory" + IfTypeScript($": I{capModuleName} | ServiceFactory<I{capModuleName}>") + ")" + IfTypeScript(": express.Application") + " {", "}"))
 					{
 						code.WriteLine("const app = express();");
 						code.WriteLine("app.use(bodyParser.json());");
 						code.WriteLine("app.use(bodyParser.urlencoded({ extended: true }));");
+
+						code.WriteLine();
+						code.WriteLine("const getService" + IfTypeScript($": ServiceFactory<I{capModuleName}>") + " = typeof serviceOrFactory === 'function' ? serviceOrFactory : () => serviceOrFactory;");
 
 						foreach (var httpMethodInfo in httpServiceInfo.Methods)
 						{
@@ -385,7 +390,7 @@ namespace Facility.CodeGen.JavaScript
 								}
 
 								code.WriteLine();
-								code.WriteLine($"return service.{methodName}(request)");
+								code.WriteLine($"return getService(req, res).{methodName}(request)");
 
 								using (code.Indent())
 								{


### PR DESCRIPTION
The request context contains the express request and response. This allows the server implementation to validate the authorization, for example.

I'm interested in other ideas to address this issue. Seems like we rely on thread-local storage and/or per-request instances of the service implementation with ASP.NET, neither of which are idiomatic for node.js/express.