### PR TITLE
Only check `result.json` when expecting response body

### DIFF
--- a/example/js/exampleApi.js
+++ b/example/js/exampleApi.js
@@ -46,11 +46,13 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
+        if (status === 200) {
+          if (result.json) {
             value = result.json;
           }
-          else if (status === 202) {
+        }
+        else if (status === 202) {
+          if (result.json) {
             value = { job: result.json };
           }
         }
@@ -73,8 +75,8 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 201) {
+        if (status === 201) {
+          if (result.json) {
             value = { widget: result.json };
           }
         }
@@ -103,13 +105,13 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
+        if (status === 200) {
+          if (result.json) {
             value = { widget: result.json };
           }
-          else if (status === 304) {
-            value = { notModified: true };
-          }
+        }
+        else if (status === 304) {
+          value = { notModified: true };
         }
         if (!value) {
           return createResponseError(status, result.json);
@@ -141,10 +143,8 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 204) {
-            value = {};
-          }
+        if (status === 204) {
+          value = {};
         }
         if (!value) {
           return createResponseError(status, result.json);
@@ -172,11 +172,13 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
+        if (status === 200) {
+          if (result.json) {
             value = { widget: result.json };
           }
-          else if (status === 202) {
+        }
+        else if (status === 202) {
+          if (result.json) {
             value = { job: result.json };
           }
         }
@@ -199,8 +201,8 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
+        if (status === 200) {
+          if (result.json) {
             value = { results: result.json };
           }
         }
@@ -228,8 +230,8 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
+        if (status === 200) {
+          if (result.json) {
             value = result.json;
           }
         }
@@ -254,8 +256,8 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
+        if (status === 200) {
+          if (result.json) {
             value = { value: result.json };
           }
         }
@@ -282,8 +284,8 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
+        if (status === 200) {
+          if (result.json) {
             value = { value: result.json };
           }
         }
@@ -304,8 +306,8 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
+        if (status === 200) {
+          if (result.json) {
             value = result.json;
           }
         }
@@ -326,10 +328,8 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
-            value = {};
-          }
+        if (status === 200) {
+          value = {};
         }
         if (!value) {
           return createResponseError(status, result.json);
@@ -349,10 +349,8 @@ class ExampleApiHttpClient {
       .then(result => {
         const status = result.response.status;
         let value = null;
-        if (result.json) {
-          if (status === 200) {
-            value = {};
-          }
+        if (status === 200) {
+          value = {};
         }
         if (!value) {
           return createResponseError(status, result.json);

--- a/example/ts/src/exampleApi.ts
+++ b/example/ts/src/exampleApi.ts
@@ -49,11 +49,13 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: IGetWidgetsResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
+				if (status === 200) {
+					if (result.json) {
 						value = result.json as IGetWidgetsResponse | null;
 					}
-					else if (status === 202) {
+				}
+				else if (status === 202) {
+					if (result.json) {
 						value = { job: result.json } as IGetWidgetsResponse;
 					}
 				}
@@ -76,8 +78,8 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: ICreateWidgetResponse | null = null;
-				if (result.json) {
-					if (status === 201) {
+				if (status === 201) {
+					if (result.json) {
 						value = { widget: result.json } as ICreateWidgetResponse;
 					}
 				}
@@ -106,13 +108,13 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: IGetWidgetResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
+				if (status === 200) {
+					if (result.json) {
 						value = { widget: result.json } as IGetWidgetResponse;
 					}
-					else if (status === 304) {
-						value = { notModified: true };
-					}
+				}
+				else if (status === 304) {
+					value = { notModified: true };
 				}
 				if (!value) {
 					return createResponseError(status, result.json) as IServiceResult<IGetWidgetResponse>;
@@ -144,10 +146,8 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: IDeleteWidgetResponse | null = null;
-				if (result.json) {
-					if (status === 204) {
-						value = {};
-					}
+				if (status === 204) {
+					value = {};
 				}
 				if (!value) {
 					return createResponseError(status, result.json) as IServiceResult<IDeleteWidgetResponse>;
@@ -175,11 +175,13 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: IEditWidgetResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
+				if (status === 200) {
+					if (result.json) {
 						value = { widget: result.json } as IEditWidgetResponse;
 					}
-					else if (status === 202) {
+				}
+				else if (status === 202) {
+					if (result.json) {
 						value = { job: result.json } as IEditWidgetResponse;
 					}
 				}
@@ -202,8 +204,8 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: IGetWidgetBatchResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
+				if (status === 200) {
+					if (result.json) {
 						value = { results: result.json } as IGetWidgetBatchResponse;
 					}
 				}
@@ -231,8 +233,8 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: IGetWidgetWeightResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
+				if (status === 200) {
+					if (result.json) {
 						value = result.json as IGetWidgetWeightResponse | null;
 					}
 				}
@@ -257,8 +259,8 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: IGetPreferenceResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
+				if (status === 200) {
+					if (result.json) {
 						value = { value: result.json } as IGetPreferenceResponse;
 					}
 				}
@@ -285,8 +287,8 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: ISetPreferenceResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
+				if (status === 200) {
+					if (result.json) {
 						value = { value: result.json } as ISetPreferenceResponse;
 					}
 				}
@@ -307,8 +309,8 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: IGetInfoResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
+				if (status === 200) {
+					if (result.json) {
 						value = result.json as IGetInfoResponse | null;
 					}
 				}
@@ -329,10 +331,8 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: INotRestfulResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
-						value = {};
-					}
+				if (status === 200) {
+					value = {};
 				}
 				if (!value) {
 					return createResponseError(status, result.json) as IServiceResult<INotRestfulResponse>;
@@ -352,10 +352,8 @@ class ExampleApiHttpClient implements IExampleApi {
 			.then(result => {
 				const status = result.response.status;
 				let value: IKitchenResponse | null = null;
-				if (result.json) {
-					if (status === 200) {
-						value = {};
-					}
+				if (status === 200) {
+					value = {};
 				}
 				if (!value) {
 					return createResponseError(status, result.json) as IServiceResult<IKitchenResponse>;

--- a/tests/Facility.CodeGen.JavaScript.UnitTests/JavaScriptGeneratorTests.cs
+++ b/tests/Facility.CodeGen.JavaScript.UnitTests/JavaScriptGeneratorTests.cs
@@ -114,8 +114,8 @@ export enum ObsoleteEnum {
 			// `createWidget` does expect response body
 			const string expectedCreateWidgetLines = @"
 				let value: ICreateWidgetResponse | null = null;
-				if (result.json) {
-					if (status === 201) {
+				if (status === 201) {
+					if (result.json) {
 						value = { widget: result.json } as ICreateWidgetResponse;
 					}
 				}";

--- a/tests/Facility.CodeGen.JavaScript.UnitTests/JavaScriptGeneratorTests.cs
+++ b/tests/Facility.CodeGen.JavaScript.UnitTests/JavaScriptGeneratorTests.cs
@@ -80,5 +80,46 @@ export enum ObsoleteEnum {
 
 			Assert.That(typesFile.Text, Contains.Substring(expectedEnumUsage));
 		}
+
+		[Test]
+		public void GenerateExampleApiTypeScript_DoesntRequireJsonWhenNoResponseBodyExpected()
+		{
+			ServiceInfo service;
+			const string fileName = "Facility.CodeGen.JavaScript.UnitTests.ExampleApi.fsd";
+			var parser = new FsdParser();
+			var stream = GetType().GetTypeInfo().Assembly.GetManifestResourceStream(fileName)!;
+			Assert.IsNotNull(stream);
+			using (var reader = new StreamReader(stream))
+				service = parser.ParseDefinition(new ServiceDefinitionText(Path.GetFileName(fileName), reader.ReadToEnd()));
+
+			var generator = new JavaScriptGenerator
+			{
+				GeneratorName = "JavaScriptGeneratorTests",
+				TypeScript = true,
+				NewLine = "\n",
+			};
+			var result = generator.GenerateOutput(service);
+			Assert.IsNotNull(result);
+
+			var apiFile = result.Files.Single(f => f.Name == "exampleApi.ts");
+
+			// `deleteWidget` does not expect response body
+			const string expectedDeleteWidgetLines = @"
+				let value: IDeleteWidgetResponse | null = null;
+				if (status === 204) {
+					value = {};
+				}";
+			Assert.That(apiFile.Text, Contains.Substring(expectedDeleteWidgetLines));
+
+			// `createWidget` does expect response body
+			const string expectedCreateWidgetLines = @"
+				let value: ICreateWidgetResponse | null = null;
+				if (result.json) {
+					if (status === 201) {
+						value = { widget: result.json } as ICreateWidgetResponse;
+					}
+				}";
+			Assert.That(apiFile.Text, Contains.Substring(expectedCreateWidgetLines));
+		}
 	}
 }


### PR DESCRIPTION
When responses do not contain a body (as is [required for `204 No Content` responses][1]), generated JS/TS clients are currently still checking for `result.json`, which is not defined in these cases. This causes them to reach the `return createResponseError` statement, even when the response has the expected status.

[1]: https://httpwg.org/specs/rfc9110.html#status.204