### PR TITLE
Add JsonSchema support to fastify plugin.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -208,6 +208,7 @@ dotnet_diagnostic.IDE0161.severity = suggestion
 dotnet_diagnostic.IDE0170.severity = suggestion
 dotnet_diagnostic.IDE0180.severity = warning
 dotnet_diagnostic.IDE1005.severity = suggestion
+dotnet_diagnostic.JSON002.severity = suggestion
 dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.SA1003.severity = none
 dotnet_diagnostic.SA1008.severity = none

--- a/conformance/src/fastify/conformanceApiPlugin.ts
+++ b/conformance/src/fastify/conformanceApiPlugin.ts
@@ -41,6 +41,10 @@ export type ConformanceApiPluginOptions = RegisterOptions & {
 export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOptions> = async (fastify, opts) => {
   const { api, caseInsenstiveQueryStringKeys, includeErrorDetails } = opts;
 
+  for (const jsonSchema of jsonSchemas) {
+    fastify.addSchema(jsonSchema);
+  }
+
   fastify.setErrorHandler((error, req, res) => {
     req.log.error(error);
     if (includeErrorDetails) {
@@ -76,6 +80,17 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/',
     method: 'GET',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            service: { type: 'string' },
+            version: { type: 'string' },
+          },
+        },
+      },
+    },
     handler: async function (req, res) {
       const request: IGetApiInfoRequest = {};
 
@@ -99,6 +114,16 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/widgets',
     method: 'GET',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            widgets: { type: 'array', items: { $ref: 'Widget' } },
+          },
+        },
+      },
+    },
     handler: async function (req, res) {
       const request: IGetWidgetsRequest = {};
 
@@ -125,6 +150,11 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/widgets',
     method: 'POST',
+    schema: {
+      response: {
+        201: { $ref: 'Widget' },
+      },
+    },
     handler: async function (req, res) {
       const request: ICreateWidgetRequest = {};
 
@@ -155,6 +185,12 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/widgets/:id',
     method: 'GET',
+    schema: {
+      response: {
+        200: { $ref: 'Widget' },
+        304: { type: 'boolean' },
+      },
+    },
     handler: async function (req, res) {
       const request: IGetWidgetRequest = {};
 
@@ -193,6 +229,13 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/widgets/:id',
     method: 'DELETE',
+    schema: {
+      response: {
+        204: { type: 'object', additionalProperties: false },
+        404: { type: 'boolean' },
+        409: { type: 'boolean' },
+      },
+    },
     handler: async function (req, res) {
       const request: IDeleteWidgetRequest = {};
 
@@ -232,6 +275,11 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/widgets/get',
     method: 'POST',
+    schema: {
+      response: {
+        200: { type: 'array', items: { type: 'object', properties: { value: { $ref: 'Widget' }, error: { $ref: '_error' } } } },
+      },
+    },
     handler: async function (req, res) {
       const request: IGetWidgetBatchRequest = {};
 
@@ -259,6 +307,17 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/mirrorFields',
     method: 'POST',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            field: { $ref: 'Any' },
+            matrix: { type: 'array', items: { type: 'array', items: { type: 'array', items: { type: 'number' } } } },
+          },
+        },
+      },
+    },
     handler: async function (req, res) {
       const request: IMirrorFieldsRequest = {};
 
@@ -286,6 +345,11 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/checkQuery',
     method: 'GET',
+    schema: {
+      response: {
+        200: { type: 'object', additionalProperties: false },
+      },
+    },
     handler: async function (req, res) {
       const request: ICheckQueryRequest = {};
 
@@ -319,6 +383,11 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/checkPath/:string/:boolean/:double/:int32/:int64/:decimal/:enum/:datetime',
     method: 'GET',
+    schema: {
+      response: {
+        200: { type: 'object', additionalProperties: false },
+      },
+    },
     handler: async function (req, res) {
       const request: ICheckPathRequest = {};
 
@@ -352,6 +421,11 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/mirrorHeaders',
     method: 'GET',
+    schema: {
+      response: {
+        200: { type: 'object', additionalProperties: false },
+      },
+    },
     handler: async function (req, res) {
       const request: IMirrorHeadersRequest = {};
 
@@ -394,6 +468,18 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/mixed/:path',
     method: 'POST',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            normal: { type: 'string' },
+          },
+        },
+        202: { type: 'object', additionalProperties: true },
+        204: { type: 'boolean' },
+      },
+    },
     handler: async function (req, res) {
       const request: IMixedRequest = {};
 
@@ -441,6 +527,16 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/required',
     method: 'POST',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            normal: { type: 'string' },
+          },
+        },
+      },
+    },
     handler: async function (req, res) {
       const request: IRequiredRequest = {};
 
@@ -478,6 +574,11 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/mirrorBytes',
     method: 'POST',
+    schema: {
+      response: {
+        200: { type: 'string' },
+      },
+    },
     handler: async function (req, res) {
       const request: IMirrorBytesRequest = {};
 
@@ -510,6 +611,11 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/mirrorText',
     method: 'POST',
+    schema: {
+      response: {
+        200: { type: 'string' },
+      },
+    },
     handler: async function (req, res) {
       const request: IMirrorTextRequest = {};
 
@@ -542,6 +648,11 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
   fastify.route({
     url: '/bodyTypes',
     method: 'POST',
+    schema: {
+      response: {
+        200: { type: 'string' },
+      },
+    },
     handler: async function (req, res) {
       const request: IBodyTypesRequest = {};
 
@@ -566,6 +677,148 @@ export const conformanceApiPlugin: FastifyPluginAsync<ConformanceApiPluginOption
     }
   });
 }
+
+const jsonSchemas = [
+  {
+    $id: '_error',
+    type: 'object',
+    properties: {
+      code: { type: 'string' },
+      message: { type: 'string' },
+      details: { type: 'object', additionalProperties: true },
+      innerError: { $ref: '_error' },
+    }
+  } as const,
+  {
+    $id: 'Widget',
+    type: 'object',
+    properties: {
+      id: { type: 'integer' },
+      name: { type: 'string' },
+    }
+  } as const,
+  {
+    $id: 'Any',
+    type: 'object',
+    properties: {
+      string: { type: 'string' },
+      boolean: { type: 'boolean' },
+      double: { type: 'number' },
+      int32: { type: 'integer' },
+      int64: { type: 'integer' },
+      decimal: { type: 'number' },
+      datetime: { type: 'string' },
+      bytes: { type: 'string' },
+      object: { type: 'object', additionalProperties: true },
+      error: { $ref: '_error' },
+      data: { $ref: 'Any' },
+      enum: { $ref: 'Answer' },
+      array: { $ref: 'AnyArray' },
+      map: { $ref: 'AnyMap' },
+      result: { $ref: 'AnyResult' },
+      nullable: { $ref: 'AnyNullable' },
+    }
+  } as const,
+  {
+    $id: 'AnyArray',
+    type: 'object',
+    properties: {
+      string: { type: 'array', items: { type: 'string' } },
+      boolean: { type: 'array', items: { type: 'boolean' } },
+      double: { type: 'array', items: { type: 'number' } },
+      int32: { type: 'array', items: { type: 'integer' } },
+      int64: { type: 'array', items: { type: 'integer' } },
+      decimal: { type: 'array', items: { type: 'number' } },
+      datetime: { type: 'array', items: { type: 'string' } },
+      bytes: { type: 'array', items: { type: 'string' } },
+      object: { type: 'array', items: { type: 'object', additionalProperties: true } },
+      error: { type: 'array', items: { $ref: '_error' } },
+      data: { type: 'array', items: { $ref: 'Any' } },
+      enum: { type: 'array', items: { $ref: 'Answer' } },
+      array: { type: 'array', items: { type: 'array', items: { type: 'integer' } } },
+      map: { type: 'array', items: { type: 'object', additionalProperties: { type: 'integer' } } },
+      result: { type: 'array', items: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } } },
+      nullable: { type: 'array', items: { oneOf: [ { type: 'integer' }, { type: 'null' } ] } },
+    }
+  } as const,
+  {
+    $id: 'AnyMap',
+    type: 'object',
+    properties: {
+      string: { type: 'object', additionalProperties: { type: 'string' } },
+      boolean: { type: 'object', additionalProperties: { type: 'boolean' } },
+      double: { type: 'object', additionalProperties: { type: 'number' } },
+      int32: { type: 'object', additionalProperties: { type: 'integer' } },
+      int64: { type: 'object', additionalProperties: { type: 'integer' } },
+      decimal: { type: 'object', additionalProperties: { type: 'number' } },
+      datetime: { type: 'object', additionalProperties: { type: 'string' } },
+      bytes: { type: 'object', additionalProperties: { type: 'string' } },
+      object: { type: 'object', additionalProperties: { type: 'object', additionalProperties: true } },
+      error: { type: 'object', additionalProperties: { $ref: '_error' } },
+      data: { type: 'object', additionalProperties: { $ref: 'Any' } },
+      enum: { type: 'object', additionalProperties: { $ref: 'Answer' } },
+      array: { type: 'object', additionalProperties: { type: 'array', items: { type: 'integer' } } },
+      map: { type: 'object', additionalProperties: { type: 'object', additionalProperties: { type: 'integer' } } },
+      result: { type: 'object', additionalProperties: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } } },
+      nullable: { type: 'object', additionalProperties: { oneOf: [ { type: 'integer' }, { type: 'null' } ] } },
+    }
+  } as const,
+  {
+    $id: 'AnyResult',
+    type: 'object',
+    properties: {
+      string: { type: 'object', properties: { value: { type: 'string' }, error: { $ref: '_error' } } },
+      boolean: { type: 'object', properties: { value: { type: 'boolean' }, error: { $ref: '_error' } } },
+      double: { type: 'object', properties: { value: { type: 'number' }, error: { $ref: '_error' } } },
+      int32: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } },
+      int64: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } },
+      decimal: { type: 'object', properties: { value: { type: 'number' }, error: { $ref: '_error' } } },
+      datetime: { type: 'object', properties: { value: { type: 'string' }, error: { $ref: '_error' } } },
+      bytes: { type: 'object', properties: { value: { type: 'string' }, error: { $ref: '_error' } } },
+      object: { type: 'object', properties: { value: { type: 'object', additionalProperties: true }, error: { $ref: '_error' } } },
+      error: { type: 'object', properties: { value: { $ref: '_error' }, error: { $ref: '_error' } } },
+      data: { type: 'object', properties: { value: { $ref: 'Any' }, error: { $ref: '_error' } } },
+      enum: { type: 'object', properties: { value: { $ref: 'Answer' }, error: { $ref: '_error' } } },
+      array: { type: 'object', properties: { value: { type: 'array', items: { type: 'integer' } }, error: { $ref: '_error' } } },
+      map: { type: 'object', properties: { value: { type: 'object', additionalProperties: { type: 'integer' } }, error: { $ref: '_error' } } },
+      result: { type: 'object', properties: { value: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } }, error: { $ref: '_error' } } },
+      nullable: { type: 'object', properties: { value: { oneOf: [ { type: 'integer' }, { type: 'null' } ] }, error: { $ref: '_error' } } },
+    }
+  } as const,
+  {
+    $id: 'AnyNullable',
+    type: 'object',
+    properties: {
+      string: { oneOf: [ { type: 'string' }, { type: 'null' } ] },
+      boolean: { oneOf: [ { type: 'boolean' }, { type: 'null' } ] },
+      double: { oneOf: [ { type: 'number' }, { type: 'null' } ] },
+      int32: { oneOf: [ { type: 'integer' }, { type: 'null' } ] },
+      int64: { oneOf: [ { type: 'integer' }, { type: 'null' } ] },
+      decimal: { oneOf: [ { type: 'number' }, { type: 'null' } ] },
+      datetime: { oneOf: [ { type: 'string' }, { type: 'null' } ] },
+      bytes: { oneOf: [ { type: 'string' }, { type: 'null' } ] },
+      object: { oneOf: [ { type: 'object', additionalProperties: true }, { type: 'null' } ] },
+      error: { oneOf: [ { $ref: '_error' }, { type: 'null' } ] },
+      data: { oneOf: [ { $ref: 'Any' }, { type: 'null' } ] },
+      enum: { oneOf: [ { $ref: 'Answer' }, { type: 'null' } ] },
+      array: { oneOf: [ { type: 'array', items: { type: 'integer' } }, { type: 'null' } ] },
+      map: { oneOf: [ { type: 'object', additionalProperties: { type: 'integer' } }, { type: 'null' } ] },
+      result: { oneOf: [ { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } }, { type: 'null' } ] },
+    }
+  } as const,
+  {
+    $id: 'HasWidget',
+    type: 'object',
+    properties: {
+      widget: { $ref: 'Widget' },
+    }
+  } as const,
+  {
+    $id: 'Answer',
+    type: 'string',
+    enum: [ 'yes', 'no', 'maybe' ],
+  } as const,
+] as const;
 
 /** API for a Facility test server. */
 export interface IConformanceApi {

--- a/conformance/src/fastify/jsConformanceApiPlugin.js
+++ b/conformance/src/fastify/jsConformanceApiPlugin.js
@@ -34,6 +34,10 @@ function parseBoolean(value) {
 export const jsConformanceApiPlugin = async (fastify, opts) => {
   const { api, caseInsenstiveQueryStringKeys, includeErrorDetails } = opts;
 
+  for (const jsonSchema of jsonSchemas) {
+    fastify.addSchema(jsonSchema);
+  }
+
   fastify.setErrorHandler((error, req, res) => {
     req.log.error(error);
     if (includeErrorDetails) {
@@ -69,6 +73,17 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/',
     method: 'GET',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            service: { type: 'string' },
+            version: { type: 'string' },
+          },
+        },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -92,6 +107,16 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/widgets',
     method: 'GET',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            widgets: { type: 'array', items: { $ref: 'Widget' } },
+          },
+        },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -118,6 +143,11 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/widgets',
     method: 'POST',
+    schema: {
+      response: {
+        201: { $ref: 'Widget' },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -148,6 +178,12 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/widgets/:id',
     method: 'GET',
+    schema: {
+      response: {
+        200: { $ref: 'Widget' },
+        304: { type: 'boolean' },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -186,6 +222,13 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/widgets/:id',
     method: 'DELETE',
+    schema: {
+      response: {
+        204: { type: 'object', additionalProperties: false },
+        404: { type: 'boolean' },
+        409: { type: 'boolean' },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -225,6 +268,11 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/widgets/get',
     method: 'POST',
+    schema: {
+      response: {
+        200: { type: 'array', items: { type: 'object', properties: { value: { $ref: 'Widget' }, error: { $ref: '_error' } } } },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -252,6 +300,17 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/mirrorFields',
     method: 'POST',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            field: { $ref: 'Any' },
+            matrix: { type: 'array', items: { type: 'array', items: { type: 'array', items: { type: 'number' } } } },
+          },
+        },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -279,6 +338,11 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/checkQuery',
     method: 'GET',
+    schema: {
+      response: {
+        200: { type: 'object', additionalProperties: false },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -312,6 +376,11 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/checkPath/:string/:boolean/:double/:int32/:int64/:decimal/:enum/:datetime',
     method: 'GET',
+    schema: {
+      response: {
+        200: { type: 'object', additionalProperties: false },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -345,6 +414,11 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/mirrorHeaders',
     method: 'GET',
+    schema: {
+      response: {
+        200: { type: 'object', additionalProperties: false },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -387,6 +461,18 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/mixed/:path',
     method: 'POST',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            normal: { type: 'string' },
+          },
+        },
+        202: { type: 'object', additionalProperties: true },
+        204: { type: 'boolean' },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -434,6 +520,16 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/required',
     method: 'POST',
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            normal: { type: 'string' },
+          },
+        },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -471,6 +567,11 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/mirrorBytes',
     method: 'POST',
+    schema: {
+      response: {
+        200: { type: 'string' },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -503,6 +604,11 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/mirrorText',
     method: 'POST',
+    schema: {
+      response: {
+        200: { type: 'string' },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -535,6 +641,11 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
   fastify.route({
     url: '/bodyTypes',
     method: 'POST',
+    schema: {
+      response: {
+        200: { type: 'string' },
+      },
+    },
     handler: async function (req, res) {
       const request = {};
 
@@ -559,3 +670,145 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     }
   });
 }
+
+const jsonSchemas = [
+  {
+    $id: '_error',
+    type: 'object',
+    properties: {
+      code: { type: 'string' },
+      message: { type: 'string' },
+      details: { type: 'object', additionalProperties: true },
+      innerError: { $ref: '_error' },
+    }
+  },
+  {
+    $id: 'Widget',
+    type: 'object',
+    properties: {
+      id: { type: 'integer' },
+      name: { type: 'string' },
+    }
+  },
+  {
+    $id: 'Any',
+    type: 'object',
+    properties: {
+      string: { type: 'string' },
+      boolean: { type: 'boolean' },
+      double: { type: 'number' },
+      int32: { type: 'integer' },
+      int64: { type: 'integer' },
+      decimal: { type: 'number' },
+      datetime: { type: 'string' },
+      bytes: { type: 'string' },
+      object: { type: 'object', additionalProperties: true },
+      error: { $ref: '_error' },
+      data: { $ref: 'Any' },
+      enum: { $ref: 'Answer' },
+      array: { $ref: 'AnyArray' },
+      map: { $ref: 'AnyMap' },
+      result: { $ref: 'AnyResult' },
+      nullable: { $ref: 'AnyNullable' },
+    }
+  },
+  {
+    $id: 'AnyArray',
+    type: 'object',
+    properties: {
+      string: { type: 'array', items: { type: 'string' } },
+      boolean: { type: 'array', items: { type: 'boolean' } },
+      double: { type: 'array', items: { type: 'number' } },
+      int32: { type: 'array', items: { type: 'integer' } },
+      int64: { type: 'array', items: { type: 'integer' } },
+      decimal: { type: 'array', items: { type: 'number' } },
+      datetime: { type: 'array', items: { type: 'string' } },
+      bytes: { type: 'array', items: { type: 'string' } },
+      object: { type: 'array', items: { type: 'object', additionalProperties: true } },
+      error: { type: 'array', items: { $ref: '_error' } },
+      data: { type: 'array', items: { $ref: 'Any' } },
+      enum: { type: 'array', items: { $ref: 'Answer' } },
+      array: { type: 'array', items: { type: 'array', items: { type: 'integer' } } },
+      map: { type: 'array', items: { type: 'object', additionalProperties: { type: 'integer' } } },
+      result: { type: 'array', items: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } } },
+      nullable: { type: 'array', items: { oneOf: [ { type: 'integer' }, { type: 'null' } ] } },
+    }
+  },
+  {
+    $id: 'AnyMap',
+    type: 'object',
+    properties: {
+      string: { type: 'object', additionalProperties: { type: 'string' } },
+      boolean: { type: 'object', additionalProperties: { type: 'boolean' } },
+      double: { type: 'object', additionalProperties: { type: 'number' } },
+      int32: { type: 'object', additionalProperties: { type: 'integer' } },
+      int64: { type: 'object', additionalProperties: { type: 'integer' } },
+      decimal: { type: 'object', additionalProperties: { type: 'number' } },
+      datetime: { type: 'object', additionalProperties: { type: 'string' } },
+      bytes: { type: 'object', additionalProperties: { type: 'string' } },
+      object: { type: 'object', additionalProperties: { type: 'object', additionalProperties: true } },
+      error: { type: 'object', additionalProperties: { $ref: '_error' } },
+      data: { type: 'object', additionalProperties: { $ref: 'Any' } },
+      enum: { type: 'object', additionalProperties: { $ref: 'Answer' } },
+      array: { type: 'object', additionalProperties: { type: 'array', items: { type: 'integer' } } },
+      map: { type: 'object', additionalProperties: { type: 'object', additionalProperties: { type: 'integer' } } },
+      result: { type: 'object', additionalProperties: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } } },
+      nullable: { type: 'object', additionalProperties: { oneOf: [ { type: 'integer' }, { type: 'null' } ] } },
+    }
+  },
+  {
+    $id: 'AnyResult',
+    type: 'object',
+    properties: {
+      string: { type: 'object', properties: { value: { type: 'string' }, error: { $ref: '_error' } } },
+      boolean: { type: 'object', properties: { value: { type: 'boolean' }, error: { $ref: '_error' } } },
+      double: { type: 'object', properties: { value: { type: 'number' }, error: { $ref: '_error' } } },
+      int32: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } },
+      int64: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } },
+      decimal: { type: 'object', properties: { value: { type: 'number' }, error: { $ref: '_error' } } },
+      datetime: { type: 'object', properties: { value: { type: 'string' }, error: { $ref: '_error' } } },
+      bytes: { type: 'object', properties: { value: { type: 'string' }, error: { $ref: '_error' } } },
+      object: { type: 'object', properties: { value: { type: 'object', additionalProperties: true }, error: { $ref: '_error' } } },
+      error: { type: 'object', properties: { value: { $ref: '_error' }, error: { $ref: '_error' } } },
+      data: { type: 'object', properties: { value: { $ref: 'Any' }, error: { $ref: '_error' } } },
+      enum: { type: 'object', properties: { value: { $ref: 'Answer' }, error: { $ref: '_error' } } },
+      array: { type: 'object', properties: { value: { type: 'array', items: { type: 'integer' } }, error: { $ref: '_error' } } },
+      map: { type: 'object', properties: { value: { type: 'object', additionalProperties: { type: 'integer' } }, error: { $ref: '_error' } } },
+      result: { type: 'object', properties: { value: { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } }, error: { $ref: '_error' } } },
+      nullable: { type: 'object', properties: { value: { oneOf: [ { type: 'integer' }, { type: 'null' } ] }, error: { $ref: '_error' } } },
+    }
+  },
+  {
+    $id: 'AnyNullable',
+    type: 'object',
+    properties: {
+      string: { oneOf: [ { type: 'string' }, { type: 'null' } ] },
+      boolean: { oneOf: [ { type: 'boolean' }, { type: 'null' } ] },
+      double: { oneOf: [ { type: 'number' }, { type: 'null' } ] },
+      int32: { oneOf: [ { type: 'integer' }, { type: 'null' } ] },
+      int64: { oneOf: [ { type: 'integer' }, { type: 'null' } ] },
+      decimal: { oneOf: [ { type: 'number' }, { type: 'null' } ] },
+      datetime: { oneOf: [ { type: 'string' }, { type: 'null' } ] },
+      bytes: { oneOf: [ { type: 'string' }, { type: 'null' } ] },
+      object: { oneOf: [ { type: 'object', additionalProperties: true }, { type: 'null' } ] },
+      error: { oneOf: [ { $ref: '_error' }, { type: 'null' } ] },
+      data: { oneOf: [ { $ref: 'Any' }, { type: 'null' } ] },
+      enum: { oneOf: [ { $ref: 'Answer' }, { type: 'null' } ] },
+      array: { oneOf: [ { type: 'array', items: { type: 'integer' } }, { type: 'null' } ] },
+      map: { oneOf: [ { type: 'object', additionalProperties: { type: 'integer' } }, { type: 'null' } ] },
+      result: { oneOf: [ { type: 'object', properties: { value: { type: 'integer' }, error: { $ref: '_error' } } }, { type: 'null' } ] },
+    }
+  },
+  {
+    $id: 'HasWidget',
+    type: 'object',
+    properties: {
+      widget: { $ref: 'Widget' },
+    }
+  },
+  {
+    $id: 'Answer',
+    type: 'string',
+    enum: [ 'yes', 'no', 'maybe' ],
+  },
+];

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -669,7 +669,7 @@ namespace Facility.CodeGen.JavaScript
 
 										if (response.BodyField is not null)
 										{
-											code.WriteLine($"{GetJsonSchemaType(service.GetFieldType(response.BodyField.ServiceField))},");
+											code.WriteLine($"{GetJsonSchemaType(service.GetFieldType(response.BodyField.ServiceField)!)},");
 										}
 										else if (response.NormalFields?.Count > 0)
 										{
@@ -679,7 +679,7 @@ namespace Facility.CodeGen.JavaScript
 												using (code.Block("properties: {", "},"))
 												{
 													foreach (var normalField in response.NormalFields)
-														code.WriteLine($"{normalField.ServiceField.Name}: {GetJsonSchemaType(service.GetFieldType(normalField.ServiceField))},");
+														code.WriteLine($"{normalField.ServiceField.Name}: {GetJsonSchemaType(service.GetFieldType(normalField.ServiceField)!)},");
 												}
 											}
 										}
@@ -820,11 +820,8 @@ namespace Facility.CodeGen.JavaScript
 
 			return new CodeGenOutput(file);
 
-			string GetJsonSchemaType(ServiceTypeInfo? serviceType)
+			string GetJsonSchemaType(ServiceTypeInfo serviceType)
 			{
-				if (serviceType is null)
-					throw new ArgumentNullException(nameof(serviceType));
-
 				return serviceType.Kind switch
 				{
 					ServiceTypeKind.String or ServiceTypeKind.Bytes or ServiceTypeKind.DateTime or ServiceTypeKind.ExternalEnum => $"{{ type: '{"string"}' }}",
@@ -870,7 +867,7 @@ namespace Facility.CodeGen.JavaScript
 							using (code.Block("properties: {", "}"))
 							{
 								foreach (var field in dto.Fields)
-									code.WriteLine($"{field.Name}: {GetJsonSchemaType(service.GetFieldType(field))},");
+									code.WriteLine($"{field.Name}: {GetJsonSchemaType(service.GetFieldType(field)!)},");
 							}
 						}
 					}

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -820,25 +820,22 @@ namespace Facility.CodeGen.JavaScript
 
 			return new CodeGenOutput(file);
 
-			string GetJsonSchemaType(ServiceTypeInfo serviceType)
+			string GetJsonSchemaType(ServiceTypeInfo serviceType) => serviceType.Kind switch
 			{
-				return serviceType.Kind switch
-				{
-					ServiceTypeKind.String or ServiceTypeKind.Bytes or ServiceTypeKind.DateTime or ServiceTypeKind.ExternalEnum => $"{{ type: '{"string"}' }}",
-					ServiceTypeKind.Boolean => $"{{ type: '{"boolean"}' }}",
-					ServiceTypeKind.Double or ServiceTypeKind.Decimal => $"{{ type: '{"number"}' }}",
-					ServiceTypeKind.Int32 or ServiceTypeKind.Int64 => $"{{ type: '{"integer"}' }}",
-					ServiceTypeKind.Object or ServiceTypeKind.ExternalDto => $"{{ type: '{"object"}', additionalProperties: true }}",
-					ServiceTypeKind.Error => $"{{ $ref: '{"_error"}' }}",
-					ServiceTypeKind.Dto => $"{{ $ref: '{serviceType.Dto!.Name}' }}",
-					ServiceTypeKind.Enum => $"{{ $ref: '{serviceType.Enum!.Name}' }}",
-					ServiceTypeKind.Result => $"{{ type: 'object', properties: {{ value: {GetJsonSchemaType(serviceType.ValueType!)}, error: {{ $ref: '_error' }} }} }}",
-					ServiceTypeKind.Array => $"{{ type: 'array', items: {GetJsonSchemaType(serviceType.ValueType!)} }}",
-					ServiceTypeKind.Map => $"{{ type: 'object', additionalProperties: {GetJsonSchemaType(serviceType.ValueType!)} }}",
-					ServiceTypeKind.Nullable => $"{{ oneOf: [ {GetJsonSchemaType(serviceType.ValueType!)}, {{ type: 'null' }} ] }}",
-					_ => throw new NotSupportedException($"Unsupported service type '{serviceType.Kind}'"),
-				};
-			}
+				ServiceTypeKind.String or ServiceTypeKind.Bytes or ServiceTypeKind.DateTime or ServiceTypeKind.ExternalEnum => "{ type: 'string' }",
+				ServiceTypeKind.Boolean => "{ type: 'boolean' }",
+				ServiceTypeKind.Double or ServiceTypeKind.Decimal => "{ type: 'number' }",
+				ServiceTypeKind.Int32 or ServiceTypeKind.Int64 => "{ type: 'integer' }",
+				ServiceTypeKind.Object or ServiceTypeKind.ExternalDto => "{ type: 'object', additionalProperties: true }",
+				ServiceTypeKind.Error => "{ $ref: '_error' }",
+				ServiceTypeKind.Dto => $"{{ $ref: '{serviceType.Dto!.Name}' }}",
+				ServiceTypeKind.Enum => $"{{ $ref: '{serviceType.Enum!.Name}' }}",
+				ServiceTypeKind.Result => $"{{ type: 'object', properties: {{ value: {GetJsonSchemaType(serviceType.ValueType!)}, error: {{ $ref: '_error' }} }} }}",
+				ServiceTypeKind.Array => $"{{ type: 'array', items: {GetJsonSchemaType(serviceType.ValueType!)} }}",
+				ServiceTypeKind.Map => $"{{ type: 'object', additionalProperties: {GetJsonSchemaType(serviceType.ValueType!)} }}",
+				ServiceTypeKind.Nullable => $"{{ oneOf: [ {GetJsonSchemaType(serviceType.ValueType!)}, {{ type: 'null' }} ] }}",
+				_ => throw new NotSupportedException($"Unknown field type '{serviceType.Kind}'"),
+			};
 
 			void WriteJsonSchemaDtos(CodeWriter code, ServiceInfo service)
 			{


### PR DESCRIPTION
https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/#serialization

I opted to only handle response schemas since (from my understanding) that is where most of the performance gain is at using `fast-json-stringify`. The request schemas are mostly for validation, which Facility can already take care of for us.