### PR TITLE
Add tests for current TS output of DTOs with "optional" and required fields.

### DIFF
--- a/tests/Facility.CodeGen.JavaScript.UnitTests/JavaScriptGeneratorTests.cs
+++ b/tests/Facility.CodeGen.JavaScript.UnitTests/JavaScriptGeneratorTests.cs
@@ -314,6 +314,42 @@ namespace Facility.CodeGen.JavaScript.UnitTests
 			Assert.That(typesFile.Text, Contains.Substring(expectedErrorSet));
 		}
 
+		[Test]
+		public void GenerateExampleApiTypeScript_DataPropertiesOptional()
+		{
+			const string definition = "service TestApi { data Widget { id: string; name: string; price: decimal; } }";
+			var parser = CreateParser();
+			var service = parser.ParseDefinition(new ServiceDefinitionText("TestApi.fsd", definition));
+			var generator = new JavaScriptGenerator { GeneratorName = "JavaScriptGeneratorTests", TypeScript = true };
+			var result = generator.GenerateOutput(service);
+			Assert.That(result, Is.Not.Null);
+
+			var typesFile = result.Files.Single(f => f.Name == "testApiTypes.ts");
+			Assert.That(typesFile.Text, Does.Contain("export interface IWidget {"));
+			Assert.That(typesFile.Text, Does.Contain("id?: string;"));
+			Assert.That(typesFile.Text, Does.Contain("name?: string;"));
+			Assert.That(typesFile.Text, Does.Contain("price?: number;"));
+			Assert.That(typesFile.Text, Does.Contain("}"));
+		}
+
+		[Test]
+		public void GenerateExampleApiTypeScript_DataPropertiesRequired()
+		{
+			const string definition = "service TestApi { data Widget { [required] id: string; name: string!; price: decimal; } }";
+			var parser = CreateParser();
+			var service = parser.ParseDefinition(new ServiceDefinitionText("TestApi.fsd", definition));
+			var generator = new JavaScriptGenerator { GeneratorName = "JavaScriptGeneratorTests", TypeScript = true };
+			var result = generator.GenerateOutput(service);
+			Assert.That(result, Is.Not.Null);
+
+			var typesFile = result.Files.Single(f => f.Name == "testApiTypes.ts");
+			Assert.That(typesFile.Text, Does.Contain("export interface IWidget {"));
+			Assert.That(typesFile.Text, Does.Contain("id?: string;"));
+			Assert.That(typesFile.Text, Does.Contain("name?: string;"));
+			Assert.That(typesFile.Text, Does.Contain("price?: number;"));
+			Assert.That(typesFile.Text, Does.Contain("}"));
+		}
+
 		[TestCase("", true)]
 		[TestCase("", false)]
 		[TestCase("suffix", true)]


### PR DESCRIPTION
Add tests for current TS output of [DTOs](https://facilityapi.github.io/define/fsd#data-transfer-objects) with "optional" or required [fields](https://facilityapi.github.io/define/fsd#fields) (see "Required Fields" section, can't hyperlink).

**Context**: [This issue](https://github.com/FacilityApi/FacilityJavaScript/issues/34) mentions wanting support for required fields as a minimum. Recently, [others mentioned](https://git.faithlife.dev/Logos/bible-study-builder/pull/174#discussion_r330241) wanting this behavior.

**Follow up - Implementation**: A follow up [PR](https://github.com/heymb/FacilityJavaScript/pull/1) implements minimum support for required fields. It seemed better to break out adding tests for existing behavior into this PR that can be merged first and adding support can be merged after as a follow up PR.