### PR TITLE
Support required fields as not optional in TS.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>2.11.1</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <PackageValidationBaselineVersion>2.8.0</PackageValidationBaselineVersion>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,10 @@
 
 These are the NuGet package releases. See also [npm Release Notes](ReleaseNotesNpm.md).
 
+## 3.0.0
+
+* Support required fields as not optional in TypeScript.
+
 ## 2.11.1
 
 * Ignore events for now.

--- a/conformance/src/conformanceApiTypes.ts
+++ b/conformance/src/conformanceApiTypes.ts
@@ -88,7 +88,7 @@ export interface ICreateWidgetResponse {
 /** Request for GetWidget. */
 export interface IGetWidgetRequest {
   /** The widget ID. */
-  id?: number;
+  id: number;
 
   /** Don't get the widget if it has this ETag. */
   ifNotETag?: string;
@@ -127,7 +127,7 @@ export interface IDeleteWidgetResponse {
 /** Request for GetWidgetBatch. */
 export interface IGetWidgetBatchRequest {
   /** The IDs of the widgets to return. */
-  ids?: number[];
+  ids: number[];
 }
 
 /** Response for GetWidgetBatch. */
@@ -258,9 +258,9 @@ export interface IMixedResponse {
 
 /** Request for Required. */
 export interface IRequiredRequest {
-  query?: string;
+  query: string;
 
-  normal?: string;
+  normal: string;
 
   widget?: IWidget;
 
@@ -281,7 +281,7 @@ export interface IRequiredRequest {
 
 /** Response for Required. */
 export interface IRequiredResponse {
-  normal?: string;
+  normal: string;
 }
 
 /** Request for MirrorBytes. */
@@ -328,7 +328,7 @@ export interface IWidget {
   id?: number;
 
   /** The name of the widget. */
-  name?: string;
+  name: string;
 }
 
 export interface IAny {

--- a/conformance/src/fastify/conformanceApiPlugin.ts
+++ b/conformance/src/fastify/conformanceApiPlugin.ts
@@ -905,7 +905,7 @@ export interface ICreateWidgetResponse {
 /** Request for GetWidget. */
 export interface IGetWidgetRequest {
   /** The widget ID. */
-  id?: number;
+  id: number;
 
   /** Don't get the widget if it has this ETag. */
   ifNotETag?: string;
@@ -944,7 +944,7 @@ export interface IDeleteWidgetResponse {
 /** Request for GetWidgetBatch. */
 export interface IGetWidgetBatchRequest {
   /** The IDs of the widgets to return. */
-  ids?: number[];
+  ids: number[];
 }
 
 /** Response for GetWidgetBatch. */
@@ -1075,9 +1075,9 @@ export interface IMixedResponse {
 
 /** Request for Required. */
 export interface IRequiredRequest {
-  query?: string;
+  query: string;
 
-  normal?: string;
+  normal: string;
 
   widget?: IWidget;
 
@@ -1098,7 +1098,7 @@ export interface IRequiredRequest {
 
 /** Response for Required. */
 export interface IRequiredResponse {
-  normal?: string;
+  normal: string;
 }
 
 /** Request for MirrorBytes. */
@@ -1145,7 +1145,7 @@ export interface IWidget {
   id?: number;
 
   /** The name of the widget. */
-  name?: string;
+  name: string;
 }
 
 export interface IAny {

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -930,7 +930,7 @@ namespace Facility.CodeGen.JavaScript
 				{
 					code.WriteLineSkipOnce();
 					WriteJsDoc(code, fieldInfo);
-					code.WriteLine($"{fieldInfo.Name}?: {RenderFieldType(service.GetFieldType(fieldInfo)!)};");
+					code.WriteLine($"{fieldInfo.Name}{(fieldInfo.IsRequired ? "" : "?")}: {RenderFieldType(service.GetFieldType(fieldInfo)!)};");
 				}
 			}
 		}

--- a/tests/Facility.CodeGen.JavaScript.UnitTests/JavaScriptGeneratorTests.cs
+++ b/tests/Facility.CodeGen.JavaScript.UnitTests/JavaScriptGeneratorTests.cs
@@ -344,8 +344,8 @@ namespace Facility.CodeGen.JavaScript.UnitTests
 
 			var typesFile = result.Files.Single(f => f.Name == "testApiTypes.ts");
 			Assert.That(typesFile.Text, Does.Contain("export interface IWidget {"));
-			Assert.That(typesFile.Text, Does.Contain("id?: string;"));
-			Assert.That(typesFile.Text, Does.Contain("name?: string;"));
+			Assert.That(typesFile.Text, Does.Contain("id: string;"));
+			Assert.That(typesFile.Text, Does.Contain("name: string;"));
 			Assert.That(typesFile.Text, Does.Contain("price?: number;"));
 			Assert.That(typesFile.Text, Does.Contain("}"));
 		}


### PR DESCRIPTION
- [x] Implement minimum support for https://github.com/FacilityApi/FacilityJavaScript/issues/34. Does _not_ add other validation.
> At minimum, we could make the fields not optional in TypeScript.

- [x] Update test added in #68.
- [x] Run codegen since [this FSD](https://github.com/FacilityApi/FacilityJavaScript/blob/6cf497481e4287741ee810c4cb90af64a59dc8be/conformance/ConformanceApi.fsd) file has required fields.
- [x] Update version and release notes since moving from generating all DTO fields as optional properties in TS to required fields are not optional is a **breaking change**.