### PR TITLE
Export HttpClient class and publish version 3.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
-    <PackageValidationBaselineVersion>3.1.0</PackageValidationBaselineVersion>
+    <VersionPrefix>3.4.0</VersionPrefix>
+    <PackageValidationBaselineVersion>3.3.0</PackageValidationBaselineVersion>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,10 @@
 
 These are the NuGet package releases. See also [npm Release Notes](ReleaseNotesNpm.md).
 
+## 3.4.0
+
+* Export generated HttpClient class, allowing the class to be extended.
+
 ## 3.3.0
 
 * Allow for request scoped services in fastify plugin.

--- a/conformance/src/conformanceApi.ts
+++ b/conformance/src/conformanceApi.ts
@@ -6,8 +6,8 @@ import { IConformanceApi, IGetApiInfoRequest, IGetApiInfoResponse, IGetWidgetsRe
 export * from './conformanceApiTypes';
 
 /** Provides access to ConformanceApi over HTTP via fetch. */
-export function createHttpClient({ fetch, baseUri }: IHttpClientOptions): IConformanceApi {
-  return new ConformanceApiHttpClient(fetch, baseUri);
+export function createHttpClient(options: IHttpClientOptions): IConformanceApi {
+  return new ConformanceApiHttpClient(options);
 }
 
 const { fetchResponse, createResponseError, createRequiredRequestFieldError } = HttpClientUtility;
@@ -27,8 +27,9 @@ function parseBoolean(value: string | undefined) {
   return undefined;
 }
 
-class ConformanceApiHttpClient implements IConformanceApi {
-  constructor(fetch: IFetch, baseUri?: string) {
+/** Provides access to ConformanceApi over HTTP via fetch. */
+export class ConformanceApiHttpClient implements IConformanceApi {
+  constructor({ fetch, baseUri }: IHttpClientOptions) {
     if (typeof fetch !== 'function') {
       throw new TypeError('fetch must be a function.');
     }

--- a/conformance/src/jsConformanceApi.js
+++ b/conformance/src/jsConformanceApi.js
@@ -5,8 +5,8 @@
 import { HttpClientUtility } from 'facility-core';
 
 /** Provides access to JsConformanceApi over HTTP via fetch. */
-export function createHttpClient({ fetch, baseUri }) {
-  return new JsConformanceApiHttpClient(fetch, baseUri);
+export function createHttpClient(options) {
+  return new JsConformanceApiHttpClient(options);
 }
 
 const { fetchResponse, createResponseError, createRequiredRequestFieldError } = HttpClientUtility;
@@ -24,8 +24,9 @@ function parseBoolean(value) {
   return undefined;
 }
 
-class JsConformanceApiHttpClient {
-  constructor(fetch, baseUri) {
+/** Provides access to JsConformanceApi over HTTP via fetch. */
+export class JsConformanceApiHttpClient {
+  constructor({ fetch, baseUri }) {
     if (typeof fetch !== 'function') {
       throw new TypeError('fetch must be a function.');
     }

--- a/example/js/exampleApi.js
+++ b/example/js/exampleApi.js
@@ -5,14 +5,15 @@
 import { HttpClientUtility } from 'facility-core';
 
 /** Provides access to ExampleApi over HTTP via fetch. */
-export function createHttpClient({ fetch, baseUri }) {
-  return new ExampleApiHttpClient(fetch, baseUri);
+export function createHttpClient(options) {
+  return new ExampleApiHttpClient(options);
 }
 
 const { fetchResponse, createResponseError, createRequiredRequestFieldError } = HttpClientUtility;
 
-class ExampleApiHttpClient {
-  constructor(fetch, baseUri) {
+/** Provides access to ExampleApi over HTTP via fetch. */
+export class ExampleApiHttpClient {
+  constructor({ fetch, baseUri }) {
     if (typeof fetch !== 'function') {
       throw new TypeError('fetch must be a function.');
     }

--- a/example/ts/src/exampleApi.ts
+++ b/example/ts/src/exampleApi.ts
@@ -6,16 +6,17 @@ import { IExampleApi, IGetWidgetsRequest, IGetWidgetsResponse, ICreateWidgetRequ
 export * from './exampleApiTypes';
 
 /** Provides access to ExampleApi over HTTP via fetch. */
-export function createHttpClient({ fetch, baseUri }: IHttpClientOptions): IExampleApi {
-	return new ExampleApiHttpClient(fetch, baseUri);
+export function createHttpClient(options: IHttpClientOptions): IExampleApi {
+	return new ExampleApiHttpClient(options);
 }
 
 const { fetchResponse, createResponseError, createRequiredRequestFieldError } = HttpClientUtility;
 type IFetch = HttpClientUtility.IFetch;
 type IFetchRequest = HttpClientUtility.IFetchRequest;
 
-class ExampleApiHttpClient implements IExampleApi {
-	constructor(fetch: IFetch, baseUri?: string) {
+/** Provides access to ExampleApi over HTTP via fetch. */
+export class ExampleApiHttpClient implements IExampleApi {
+	constructor({ fetch, baseUri }: IHttpClientOptions) {
 		if (typeof fetch !== 'function') {
 			throw new TypeError('fetch must be a function.');
 		}

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -162,8 +162,8 @@ namespace Facility.CodeGen.JavaScript
 
 				code.WriteLine();
 				WriteJsDoc(code, $"Provides access to {capModuleName} over HTTP via fetch.");
-				using (code.Block("export function createHttpClient({ fetch, baseUri }" + IfTypeScript(": IHttpClientOptions") + ")" + IfTypeScript($": I{capModuleName}") + " {", "}"))
-					code.WriteLine($"return new {capModuleName}HttpClient(fetch, baseUri);");
+				using (code.Block("export function createHttpClient(options" + IfTypeScript(": IHttpClientOptions") + ")" + IfTypeScript($": I{capModuleName}") + " {", "}"))
+					code.WriteLine($"return new {capModuleName}HttpClient(options);");
 
 				code.WriteLine();
 				code.WriteLine("const { fetchResponse, createResponseError, createRequiredRequestFieldError } = HttpClientUtility;");
@@ -192,9 +192,10 @@ namespace Facility.CodeGen.JavaScript
 				}
 
 				code.WriteLine();
-				using (code.Block($"class {capModuleName}HttpClient" + IfTypeScript($" implements I{capModuleName}") + " {", "}"))
+				WriteJsDoc(code, $"Provides access to {capModuleName} over HTTP via fetch.");
+				using (code.Block($"export class {capModuleName}HttpClient" + IfTypeScript($" implements I{capModuleName}") + " {", "}"))
 				{
-					using (code.Block("constructor(fetch" + IfTypeScript(": IFetch") + ", baseUri" + IfTypeScript("?: string") + ") {", "}"))
+					using (code.Block("constructor({ fetch, baseUri }" + IfTypeScript(": IHttpClientOptions") + ") {", "}"))
 					{
 						using (code.Block("if (typeof fetch !== 'function') {", "}"))
 							code.WriteLine("throw new TypeError('fetch must be a function.');");


### PR DESCRIPTION
Export the generated HttpClient class to allow for extension. Update the version to 3.4.0 in the project configuration.