### PR TITLE
Misc fastify improvements.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.6.0</VersionPrefix>
-    <PackageValidationBaselineVersion>3.5.0</PackageValidationBaselineVersion>
+    <VersionPrefix>3.7.0</VersionPrefix>
+    <PackageValidationBaselineVersion>3.6.0</PackageValidationBaselineVersion>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,11 @@
 
 These are the NuGet package releases. See also [npm Release Notes](ReleaseNotesNpm.md).
 
+## 3.7.0
+
+* Add `4xx` and `5xx` response schemas to fastify plugin.
+* Send explicit return values in fastify plugin.
+
 ## 3.6.0
 
 * Add client support for events (Server-Sent Events).

--- a/conformance/src/fastify/app.ts
+++ b/conformance/src/fastify/app.ts
@@ -8,7 +8,7 @@ const app: FastifyPluginAsync<FastifyServerOptions> = async (fastify): Promise<v
 	const conformanceApiPluginOptions: ConformanceApiPluginOptions = {
 		serviceOrFactory: () =>
 			new ConformanceApiService(conformanceTestsJson.tests),
-		caseInsenstiveQueryStringKeys: true,
+		caseInsensitiveQueryStringKeys: true,
 		includeErrorDetails: true,
 	};
 

--- a/conformance/src/fastify/conformanceApiPlugin.ts
+++ b/conformance/src/fastify/conformanceApiPlugin.ts
@@ -79,13 +79,17 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).getApiInfo(request as IGetApiInfoRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        res.status(200).send(result.value);
+        const value = result.value;
+        res.status(200);
+        res.send({
+          service: value.service,
+          version: value.version,
+        } satisfies IGetApiInfoResponse);
         return;
       }
 
@@ -117,13 +121,16 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).getWidgets(request as IGetWidgetsRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        res.status(200).send(result.value);
+        const value = result.value;
+        res.status(200);
+        res.send({
+          widgets: value.widgets,
+        } satisfies IGetWidgetsResponse);
         return;
       }
 
@@ -149,17 +156,20 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).createWidget(request as ICreateWidgetRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.url != null) res.header('Location', result.value.url);
-        if (result.value.eTag != null) res.header('eTag', result.value.eTag);
-
-        if (result.value.widget) {
-          res.status(201).send(result.value.widget);
+        const value = result.value;
+        if (value.url != null) res.header('Location', value.url);
+        if (value.eTag != null) res.header('eTag', value.eTag);
+        if (value.widget) {
+          res.status(201);
+          res.send({
+            id: value.widget.id,
+            name: value.widget.name,
+          } satisfies IWidget);
           return;
         }
       }
@@ -191,20 +201,23 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).getWidget(request as IGetWidgetRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.eTag != null) res.header('eTag', result.value.eTag);
-
-        if (result.value.widget) {
-          res.status(200).send(result.value.widget);
+        const value = result.value;
+        if (value.eTag != null) res.header('eTag', value.eTag);
+        if (value.widget) {
+          res.status(200);
+          res.send({
+            id: value.widget.id,
+            name: value.widget.name,
+          } satisfies IWidget);
           return;
         }
 
-        if (result.value.notModified) {
+        if (value.notModified) {
           res.status(304);
           return;
         }
@@ -238,18 +251,18 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).deleteWidget(request as IDeleteWidgetRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.notFound) {
+        const value = result.value;
+        if (value.notFound) {
           res.status(404);
           return;
         }
 
-        if (result.value.conflict) {
+        if (value.conflict) {
           res.status(409);
           return;
         }
@@ -280,14 +293,15 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).getWidgetBatch(request as IGetWidgetBatchRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.results) {
-          res.status(200).send(result.value.results);
+        const value = result.value;
+        if (value.results) {
+          res.status(200);
+          res.send(value.results);
           return;
         }
       }
@@ -322,13 +336,17 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).mirrorFields(request as IMirrorFieldsRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        res.status(200).send(result.value);
+        const value = result.value;
+        res.status(200);
+        res.send({
+          field: value.field,
+          matrix: value.matrix,
+        } satisfies IMirrorFieldsResponse);
         return;
       }
 
@@ -363,12 +381,12 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).checkQuery(request as ICheckQueryRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
+        const value = result.value;
         res.status(200);
         return;
       }
@@ -404,12 +422,12 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).checkPath(request as ICheckPathRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
+        const value = result.value;
         res.status(200);
         return;
       }
@@ -445,22 +463,21 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).mirrorHeaders(request as IMirrorHeadersRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.string != null) res.header('string', result.value.string);
-        if (result.value.boolean != null) res.header('boolean', result.value.boolean);
-        if (result.value.float != null) res.header('float', result.value.float);
-        if (result.value.double != null) res.header('double', result.value.double);
-        if (result.value.int32 != null) res.header('int32', result.value.int32);
-        if (result.value.int64 != null) res.header('int64', result.value.int64);
-        if (result.value.decimal != null) res.header('decimal', result.value.decimal);
-        if (result.value.enum != null) res.header('enum', result.value.enum);
-        if (result.value.datetime != null) res.header('datetime', result.value.datetime);
-
+        const value = result.value;
+        if (value.string != null) res.header('string', value.string);
+        if (value.boolean != null) res.header('boolean', value.boolean);
+        if (value.float != null) res.header('float', value.float);
+        if (value.double != null) res.header('double', value.double);
+        if (value.int32 != null) res.header('int32', value.int32);
+        if (value.int64 != null) res.header('int64', value.int64);
+        if (value.decimal != null) res.header('decimal', value.decimal);
+        if (value.enum != null) res.header('enum', value.enum);
+        if (value.datetime != null) res.header('datetime', value.datetime);
         res.status(200);
         return;
       }
@@ -504,25 +521,28 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).mixed(request as IMixedRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.header != null) res.header('header', result.value.header);
-
-        if (result.value.body) {
-          res.status(202).send(result.value.body);
+        const value = result.value;
+        if (value.header != null) res.header('header', value.header);
+        if (value.body) {
+          res.status(202);
+          res.send(value.body);
           return;
         }
 
-        if (result.value.empty) {
+        if (value.empty) {
           res.status(204);
           return;
         }
 
-        res.status(200).send(result.value);
+        res.status(200);
+        res.send({
+          normal: value.normal,
+        } satisfies IMixedResponse);
         return;
       }
 
@@ -565,13 +585,16 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).required(request as IRequiredRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        res.status(200).send(result.value);
+        const value = result.value;
+        res.status(200);
+        res.send({
+          normal: value.normal,
+        } satisfies IRequiredResponse);
         return;
       }
 
@@ -600,16 +623,16 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).mirrorBytes(request as IMirrorBytesRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.type != null) res.header('Content-Type', result.value.type);
-
-        if (result.value.content) {
-          res.status(200).send(result.value.content);
+        const value = result.value;
+        if (value.type != null) res.header('Content-Type', value.type);
+        if (value.content) {
+          res.status(200);
+          res.send(value.content);
           return;
         }
       }
@@ -639,16 +662,16 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).mirrorText(request as IMirrorTextRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.type != null) res.header('Content-Type', result.value.type);
-
-        if (result.value.content) {
-          res.status(200).send(result.value.content);
+        const value = result.value;
+        if (value.type != null) res.header('Content-Type', value.type);
+        if (value.content) {
+          res.status(200);
+          res.send(value.content);
           return;
         }
       }
@@ -675,14 +698,15 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       const result = await getService(req).bodyTypes(request as IBodyTypesRequest);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.content) {
-          res.status(200).send(result.value.content);
+        const value = result.value;
+        if (value.content) {
+          res.status(200);
+          res.send(value.content);
           return;
         }
       }
@@ -865,6 +889,16 @@ function parseBoolean(value: string | undefined) {
     }
   }
   return undefined;
+}
+
+function sendErrorResponse(res: fastifyTypes.FastifyReply, error: IServiceError) {
+  res.status(standardErrorCodes[error.code ?? ''] || 500);
+  res.send({
+    code: error.code,
+    message: error.message,
+    details: error.details,
+    innerError: error.innerError,
+  } satisfies IServiceError);
 }
 
 /** API for a Facility test server. */

--- a/conformance/src/fastify/conformanceApiPlugin.ts
+++ b/conformance/src/fastify/conformanceApiPlugin.ts
@@ -62,13 +62,15 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'GET',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             service: { type: 'string' },
             version: { type: 'string' },
           },
         },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -96,12 +98,14 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'GET',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             widgets: { type: 'array', items: { $ref: 'Widget' } },
           },
         },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -132,7 +136,9 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'POST',
     schema: {
       response: {
-        201: { $ref: 'Widget' },
+        '201': { $ref: 'Widget' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -167,8 +173,10 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'GET',
     schema: {
       response: {
-        200: { $ref: 'Widget' },
-        304: { type: 'boolean' },
+        '200': { $ref: 'Widget' },
+        '304': { type: 'boolean' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -211,9 +219,11 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'DELETE',
     schema: {
       response: {
-        204: { type: 'object', additionalProperties: false },
-        404: { type: 'boolean' },
-        409: { type: 'boolean' },
+        '204': { type: 'object', additionalProperties: false },
+        '404': { type: 'boolean' },
+        '409': { type: 'boolean' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -257,7 +267,9 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'POST',
     schema: {
       response: {
-        200: { type: 'array', items: { type: 'object', properties: { value: { $ref: 'Widget' }, error: { $ref: '_error' } } } },
+        '200': { type: 'array', items: { type: 'object', properties: { value: { $ref: 'Widget' }, error: { $ref: '_error' } } } },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -289,13 +301,15 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'POST',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             field: { $ref: 'Any' },
             matrix: { type: 'array', items: { type: 'array', items: { type: 'array', items: { type: 'number' } } } },
           },
         },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -327,7 +341,9 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'GET',
     schema: {
       response: {
-        200: { type: 'object', additionalProperties: false },
+        '200': { type: 'object', additionalProperties: false },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -366,7 +382,9 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'GET',
     schema: {
       response: {
-        200: { type: 'object', additionalProperties: false },
+        '200': { type: 'object', additionalProperties: false },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -405,7 +423,9 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'GET',
     schema: {
       response: {
-        200: { type: 'object', additionalProperties: false },
+        '200': { type: 'object', additionalProperties: false },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -454,14 +474,16 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'POST',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             normal: { type: 'string' },
           },
         },
-        202: { type: 'object', additionalProperties: true },
-        204: { type: 'boolean' },
+        '202': { type: 'object', additionalProperties: true },
+        '204': { type: 'boolean' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -513,12 +535,14 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'POST',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             normal: { type: 'string' },
           },
         },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -560,7 +584,9 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'POST',
     schema: {
       response: {
-        200: { type: 'string' },
+        '200': { type: 'string' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -597,7 +623,9 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'POST',
     schema: {
       response: {
-        200: { type: 'string' },
+        '200': { type: 'string' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -634,7 +662,9 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     method: 'POST',
     schema: {
       response: {
-        200: { type: 'string' },
+        '200': { type: 'string' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {

--- a/conformance/src/fastify/conformanceApiPlugin.ts
+++ b/conformance/src/fastify/conformanceApiPlugin.ts
@@ -27,8 +27,9 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
   fastify.setErrorHandler((error, req, res) => {
     req.log.error(error);
+    res.code(500);
     if (includeErrorDetails) {
-      res.status(500).send({
+      res.send({
         code: 'InternalError',
         message: error.message,
         details: {
@@ -37,7 +38,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       });
     }
     else {
-      res.status(500).send({
+      res.send({
         code: 'InternalError',
         message: 'The service experienced an unexpected internal error.',
       });
@@ -85,7 +86,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         res.send({
           service: value.service,
           version: value.version,
@@ -127,7 +128,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         res.send({
           widgets: value.widgets,
         } satisfies IGetWidgetsResponse);
@@ -165,7 +166,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
         if (value.url != null) res.header('Location', value.url);
         if (value.eTag != null) res.header('eTag', value.eTag);
         if (value.widget) {
-          res.status(201);
+          res.code(201);
           res.send({
             id: value.widget.id,
             name: value.widget.name,
@@ -209,7 +210,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
         const value = result.value;
         if (value.eTag != null) res.header('eTag', value.eTag);
         if (value.widget) {
-          res.status(200);
+          res.code(200);
           res.send({
             id: value.widget.id,
             name: value.widget.name,
@@ -218,7 +219,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
         }
 
         if (value.notModified) {
-          res.status(304);
+          res.code(304);
           return;
         }
       }
@@ -258,16 +259,16 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       if (result.value) {
         const value = result.value;
         if (value.notFound) {
-          res.status(404);
+          res.code(404);
           return;
         }
 
         if (value.conflict) {
-          res.status(409);
+          res.code(409);
           return;
         }
 
-        res.status(204);
+        res.code(204);
         return;
       }
 
@@ -300,7 +301,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       if (result.value) {
         const value = result.value;
         if (value.results) {
-          res.status(200);
+          res.code(200);
           res.send(value.results);
           return;
         }
@@ -342,7 +343,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         res.send({
           field: value.field,
           matrix: value.matrix,
@@ -387,7 +388,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         return;
       }
 
@@ -428,7 +429,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         return;
       }
 
@@ -478,7 +479,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
         if (value.decimal != null) res.header('decimal', value.decimal);
         if (value.enum != null) res.header('enum', value.enum);
         if (value.datetime != null) res.header('datetime', value.datetime);
-        res.status(200);
+        res.code(200);
         return;
       }
 
@@ -529,17 +530,17 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
         const value = result.value;
         if (value.header != null) res.header('header', value.header);
         if (value.body) {
-          res.status(202);
+          res.code(202);
           res.send(value.body);
           return;
         }
 
         if (value.empty) {
-          res.status(204);
+          res.code(204);
           return;
         }
 
-        res.status(200);
+        res.code(200);
         res.send({
           normal: value.normal,
         } satisfies IMixedResponse);
@@ -591,7 +592,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         res.send({
           normal: value.normal,
         } satisfies IRequiredResponse);
@@ -631,7 +632,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
         const value = result.value;
         if (value.type != null) res.header('Content-Type', value.type);
         if (value.content) {
-          res.status(200);
+          res.code(200);
           res.send(value.content);
           return;
         }
@@ -670,7 +671,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
         const value = result.value;
         if (value.type != null) res.header('Content-Type', value.type);
         if (value.content) {
-          res.status(200);
+          res.code(200);
           res.send(value.content);
           return;
         }
@@ -705,7 +706,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
       if (result.value) {
         const value = result.value;
         if (value.content) {
-          res.status(200);
+          res.code(200);
           res.send(value.content);
           return;
         }
@@ -892,7 +893,7 @@ function parseBoolean(value: string | undefined) {
 }
 
 function sendErrorResponse(res: fastifyTypes.FastifyReply, error: IServiceError) {
-  res.status(standardErrorCodes[error.code ?? ''] || 500);
+  res.code(standardErrorCodes[error.code ?? ''] || 500);
   res.send({
     code: error.code,
     message: error.message,

--- a/conformance/src/fastify/conformanceApiPlugin.ts
+++ b/conformance/src/fastify/conformanceApiPlugin.ts
@@ -9,7 +9,7 @@ export type ConformanceApiPluginOptions = fastifyTypes.RegisterOptions & {
   serviceOrFactory: IConformanceApi | ((req: fastifyTypes.FastifyRequest) => IConformanceApi);
 
   /** Whether to make query string keys case insensitive. Defalts to false. */
-  caseInsenstiveQueryStringKeys?: boolean;
+  caseInsensitiveQueryStringKeys?: boolean;
 
   /** Whether to include error details in the response. Defaults to false. */
   includeErrorDetails?: boolean;
@@ -17,7 +17,7 @@ export type ConformanceApiPluginOptions = fastifyTypes.RegisterOptions & {
 
 /** EXPERIMENTAL: The generated code for this plugin is subject to change/removal without a major version bump. */
 export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceApiPluginOptions> = async (fastify, opts) => {
-  const { serviceOrFactory, caseInsenstiveQueryStringKeys, includeErrorDetails } = opts;
+  const { serviceOrFactory, caseInsensitiveQueryStringKeys, includeErrorDetails } = opts;
 
   const getService = typeof serviceOrFactory === 'function' ? serviceOrFactory : () => serviceOrFactory;
 
@@ -44,7 +44,7 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
     }
   });
 
-  if (caseInsenstiveQueryStringKeys) {
+  if (caseInsensitiveQueryStringKeys) {
     fastify.addHook('onRequest', async (req, res) => {
       const query = req.query as Record<string, string>;
       for (const key of Object.keys(query)) {

--- a/conformance/src/fastify/jsConformanceApiPlugin.js
+++ b/conformance/src/fastify/jsConformanceApiPlugin.js
@@ -49,13 +49,15 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'GET',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             service: { type: 'string' },
             version: { type: 'string' },
           },
         },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -83,12 +85,14 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'GET',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             widgets: { type: 'array', items: { $ref: 'Widget' } },
           },
         },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -119,7 +123,9 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'POST',
     schema: {
       response: {
-        201: { $ref: 'Widget' },
+        '201': { $ref: 'Widget' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -154,8 +160,10 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'GET',
     schema: {
       response: {
-        200: { $ref: 'Widget' },
-        304: { type: 'boolean' },
+        '200': { $ref: 'Widget' },
+        '304': { type: 'boolean' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -198,9 +206,11 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'DELETE',
     schema: {
       response: {
-        204: { type: 'object', additionalProperties: false },
-        404: { type: 'boolean' },
-        409: { type: 'boolean' },
+        '204': { type: 'object', additionalProperties: false },
+        '404': { type: 'boolean' },
+        '409': { type: 'boolean' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -244,7 +254,9 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'POST',
     schema: {
       response: {
-        200: { type: 'array', items: { type: 'object', properties: { value: { $ref: 'Widget' }, error: { $ref: '_error' } } } },
+        '200': { type: 'array', items: { type: 'object', properties: { value: { $ref: 'Widget' }, error: { $ref: '_error' } } } },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -276,13 +288,15 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'POST',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             field: { $ref: 'Any' },
             matrix: { type: 'array', items: { type: 'array', items: { type: 'array', items: { type: 'number' } } } },
           },
         },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -314,7 +328,9 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'GET',
     schema: {
       response: {
-        200: { type: 'object', additionalProperties: false },
+        '200': { type: 'object', additionalProperties: false },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -353,7 +369,9 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'GET',
     schema: {
       response: {
-        200: { type: 'object', additionalProperties: false },
+        '200': { type: 'object', additionalProperties: false },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -392,7 +410,9 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'GET',
     schema: {
       response: {
-        200: { type: 'object', additionalProperties: false },
+        '200': { type: 'object', additionalProperties: false },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -441,14 +461,16 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'POST',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             normal: { type: 'string' },
           },
         },
-        202: { type: 'object', additionalProperties: true },
-        204: { type: 'boolean' },
+        '202': { type: 'object', additionalProperties: true },
+        '204': { type: 'boolean' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -500,12 +522,14 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'POST',
     schema: {
       response: {
-        200: {
+        '200': {
           type: 'object',
           properties: {
             normal: { type: 'string' },
           },
         },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -547,7 +571,9 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'POST',
     schema: {
       response: {
-        200: { type: 'string' },
+        '200': { type: 'string' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -584,7 +610,9 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'POST',
     schema: {
       response: {
-        200: { type: 'string' },
+        '200': { type: 'string' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {
@@ -621,7 +649,9 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     method: 'POST',
     schema: {
       response: {
-        200: { type: 'string' },
+        '200': { type: 'string' },
+        '4xx': { $ref: '_error' },
+        '5xx': { $ref: '_error' },
       },
     },
     handler: async function (req, res) {

--- a/conformance/src/fastify/jsConformanceApiPlugin.js
+++ b/conformance/src/fastify/jsConformanceApiPlugin.js
@@ -14,8 +14,9 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
   fastify.setErrorHandler((error, req, res) => {
     req.log.error(error);
+    res.code(500);
     if (includeErrorDetails) {
-      res.status(500).send({
+      res.send({
         code: 'InternalError',
         message: error.message,
         details: {
@@ -24,7 +25,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       });
     }
     else {
-      res.status(500).send({
+      res.send({
         code: 'InternalError',
         message: 'The service experienced an unexpected internal error.',
       });
@@ -72,7 +73,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         res.send({
           service: value.service,
           version: value.version,
@@ -114,7 +115,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         res.send({
           widgets: value.widgets,
         });
@@ -152,7 +153,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
         if (value.url != null) res.header('Location', value.url);
         if (value.eTag != null) res.header('eTag', value.eTag);
         if (value.widget) {
-          res.status(201);
+          res.code(201);
           res.send({
             id: value.widget.id,
             name: value.widget.name,
@@ -196,7 +197,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
         const value = result.value;
         if (value.eTag != null) res.header('eTag', value.eTag);
         if (value.widget) {
-          res.status(200);
+          res.code(200);
           res.send({
             id: value.widget.id,
             name: value.widget.name,
@@ -205,7 +206,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
         }
 
         if (value.notModified) {
-          res.status(304);
+          res.code(304);
           return;
         }
       }
@@ -245,16 +246,16 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       if (result.value) {
         const value = result.value;
         if (value.notFound) {
-          res.status(404);
+          res.code(404);
           return;
         }
 
         if (value.conflict) {
-          res.status(409);
+          res.code(409);
           return;
         }
 
-        res.status(204);
+        res.code(204);
         return;
       }
 
@@ -287,7 +288,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       if (result.value) {
         const value = result.value;
         if (value.results) {
-          res.status(200);
+          res.code(200);
           res.send(value.results);
           return;
         }
@@ -329,7 +330,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         res.send({
           field: value.field,
           matrix: value.matrix,
@@ -374,7 +375,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         return;
       }
 
@@ -415,7 +416,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         return;
       }
 
@@ -465,7 +466,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
         if (value.decimal != null) res.header('decimal', value.decimal);
         if (value.enum != null) res.header('enum', value.enum);
         if (value.datetime != null) res.header('datetime', value.datetime);
-        res.status(200);
+        res.code(200);
         return;
       }
 
@@ -516,17 +517,17 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
         const value = result.value;
         if (value.header != null) res.header('header', value.header);
         if (value.body) {
-          res.status(202);
+          res.code(202);
           res.send(value.body);
           return;
         }
 
         if (value.empty) {
-          res.status(204);
+          res.code(204);
           return;
         }
 
-        res.status(200);
+        res.code(200);
         res.send({
           normal: value.normal,
         });
@@ -578,7 +579,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       if (result.value) {
         const value = result.value;
-        res.status(200);
+        res.code(200);
         res.send({
           normal: value.normal,
         });
@@ -618,7 +619,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
         const value = result.value;
         if (value.type != null) res.header('Content-Type', value.type);
         if (value.content) {
-          res.status(200);
+          res.code(200);
           res.send(value.content);
           return;
         }
@@ -657,7 +658,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
         const value = result.value;
         if (value.type != null) res.header('Content-Type', value.type);
         if (value.content) {
-          res.status(200);
+          res.code(200);
           res.send(value.content);
           return;
         }
@@ -692,7 +693,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       if (result.value) {
         const value = result.value;
         if (value.content) {
-          res.status(200);
+          res.code(200);
           res.send(value.content);
           return;
         }
@@ -879,7 +880,7 @@ function parseBoolean(value) {
 }
 
 function sendErrorResponse(res, error) {
-  res.status(standardErrorCodes[error.code ?? ''] || 500);
+  res.code(standardErrorCodes[error.code ?? ''] || 500);
   res.send({
     code: error.code,
     message: error.message,

--- a/conformance/src/fastify/jsConformanceApiPlugin.js
+++ b/conformance/src/fastify/jsConformanceApiPlugin.js
@@ -4,7 +4,7 @@
 
 /** EXPERIMENTAL: The generated code for this plugin is subject to change/removal without a major version bump. */
 export const jsConformanceApiPlugin = async (fastify, opts) => {
-  const { serviceOrFactory, caseInsenstiveQueryStringKeys, includeErrorDetails } = opts;
+  const { serviceOrFactory, caseInsensitiveQueryStringKeys, includeErrorDetails } = opts;
 
   const getService = typeof serviceOrFactory === 'function' ? serviceOrFactory : () => serviceOrFactory;
 
@@ -31,7 +31,7 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
     }
   });
 
-  if (caseInsenstiveQueryStringKeys) {
+  if (caseInsensitiveQueryStringKeys) {
     fastify.addHook('onRequest', async (req, res) => {
       const query = req.query;
       for (const key of Object.keys(query)) {

--- a/conformance/src/fastify/jsConformanceApiPlugin.js
+++ b/conformance/src/fastify/jsConformanceApiPlugin.js
@@ -66,13 +66,17 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).getApiInfo(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        res.status(200).send(result.value);
+        const value = result.value;
+        res.status(200);
+        res.send({
+          service: value.service,
+          version: value.version,
+        });
         return;
       }
 
@@ -104,13 +108,16 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).getWidgets(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        res.status(200).send(result.value);
+        const value = result.value;
+        res.status(200);
+        res.send({
+          widgets: value.widgets,
+        });
         return;
       }
 
@@ -136,17 +143,20 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).createWidget(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.url != null) res.header('Location', result.value.url);
-        if (result.value.eTag != null) res.header('eTag', result.value.eTag);
-
-        if (result.value.widget) {
-          res.status(201).send(result.value.widget);
+        const value = result.value;
+        if (value.url != null) res.header('Location', value.url);
+        if (value.eTag != null) res.header('eTag', value.eTag);
+        if (value.widget) {
+          res.status(201);
+          res.send({
+            id: value.widget.id,
+            name: value.widget.name,
+          });
           return;
         }
       }
@@ -178,20 +188,23 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).getWidget(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.eTag != null) res.header('eTag', result.value.eTag);
-
-        if (result.value.widget) {
-          res.status(200).send(result.value.widget);
+        const value = result.value;
+        if (value.eTag != null) res.header('eTag', value.eTag);
+        if (value.widget) {
+          res.status(200);
+          res.send({
+            id: value.widget.id,
+            name: value.widget.name,
+          });
           return;
         }
 
-        if (result.value.notModified) {
+        if (value.notModified) {
           res.status(304);
           return;
         }
@@ -225,18 +238,18 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).deleteWidget(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.notFound) {
+        const value = result.value;
+        if (value.notFound) {
           res.status(404);
           return;
         }
 
-        if (result.value.conflict) {
+        if (value.conflict) {
           res.status(409);
           return;
         }
@@ -267,14 +280,15 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).getWidgetBatch(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.results) {
-          res.status(200).send(result.value.results);
+        const value = result.value;
+        if (value.results) {
+          res.status(200);
+          res.send(value.results);
           return;
         }
       }
@@ -309,13 +323,17 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).mirrorFields(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        res.status(200).send(result.value);
+        const value = result.value;
+        res.status(200);
+        res.send({
+          field: value.field,
+          matrix: value.matrix,
+        });
         return;
       }
 
@@ -350,12 +368,12 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).checkQuery(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
+        const value = result.value;
         res.status(200);
         return;
       }
@@ -391,12 +409,12 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).checkPath(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
+        const value = result.value;
         res.status(200);
         return;
       }
@@ -432,22 +450,21 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).mirrorHeaders(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.string != null) res.header('string', result.value.string);
-        if (result.value.boolean != null) res.header('boolean', result.value.boolean);
-        if (result.value.float != null) res.header('float', result.value.float);
-        if (result.value.double != null) res.header('double', result.value.double);
-        if (result.value.int32 != null) res.header('int32', result.value.int32);
-        if (result.value.int64 != null) res.header('int64', result.value.int64);
-        if (result.value.decimal != null) res.header('decimal', result.value.decimal);
-        if (result.value.enum != null) res.header('enum', result.value.enum);
-        if (result.value.datetime != null) res.header('datetime', result.value.datetime);
-
+        const value = result.value;
+        if (value.string != null) res.header('string', value.string);
+        if (value.boolean != null) res.header('boolean', value.boolean);
+        if (value.float != null) res.header('float', value.float);
+        if (value.double != null) res.header('double', value.double);
+        if (value.int32 != null) res.header('int32', value.int32);
+        if (value.int64 != null) res.header('int64', value.int64);
+        if (value.decimal != null) res.header('decimal', value.decimal);
+        if (value.enum != null) res.header('enum', value.enum);
+        if (value.datetime != null) res.header('datetime', value.datetime);
         res.status(200);
         return;
       }
@@ -491,25 +508,28 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).mixed(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.header != null) res.header('header', result.value.header);
-
-        if (result.value.body) {
-          res.status(202).send(result.value.body);
+        const value = result.value;
+        if (value.header != null) res.header('header', value.header);
+        if (value.body) {
+          res.status(202);
+          res.send(value.body);
           return;
         }
 
-        if (result.value.empty) {
+        if (value.empty) {
           res.status(204);
           return;
         }
 
-        res.status(200).send(result.value);
+        res.status(200);
+        res.send({
+          normal: value.normal,
+        });
         return;
       }
 
@@ -552,13 +572,16 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).required(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        res.status(200).send(result.value);
+        const value = result.value;
+        res.status(200);
+        res.send({
+          normal: value.normal,
+        });
         return;
       }
 
@@ -587,16 +610,16 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).mirrorBytes(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.type != null) res.header('Content-Type', result.value.type);
-
-        if (result.value.content) {
-          res.status(200).send(result.value.content);
+        const value = result.value;
+        if (value.type != null) res.header('Content-Type', value.type);
+        if (value.content) {
+          res.status(200);
+          res.send(value.content);
           return;
         }
       }
@@ -626,16 +649,16 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).mirrorText(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.type != null) res.header('Content-Type', result.value.type);
-
-        if (result.value.content) {
-          res.status(200).send(result.value.content);
+        const value = result.value;
+        if (value.type != null) res.header('Content-Type', value.type);
+        if (value.content) {
+          res.status(200);
+          res.send(value.content);
           return;
         }
       }
@@ -662,14 +685,15 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
       const result = await getService(req).bodyTypes(request);
 
       if (result.error) {
-        const status = result.error.code && standardErrorCodes[result.error.code];
-        res.status(status || 500).send(result.error);
+        sendErrorResponse(res, result.error);
         return;
       }
 
       if (result.value) {
-        if (result.value.content) {
-          res.status(200).send(result.value.content);
+        const value = result.value;
+        if (value.content) {
+          res.status(200);
+          res.send(value.content);
           return;
         }
       }
@@ -852,4 +876,14 @@ function parseBoolean(value) {
     }
   }
   return undefined;
+}
+
+function sendErrorResponse(res, error) {
+  res.status(standardErrorCodes[error.code ?? ''] || 500);
+  res.send({
+    code: error.code,
+    message: error.message,
+    details: error.details,
+    innerError: error.innerError,
+  });
 }

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -780,7 +780,7 @@ namespace Facility.CodeGen.JavaScript
 									foreach (var response in httpMethodInfo.ValidResponses)
 									{
 										var statusCode = (int) response.StatusCode;
-										code.Write($"{statusCode}: ");
+										code.Write($"'{statusCode}': ");
 
 										if (response.BodyField is not null)
 										{
@@ -803,6 +803,9 @@ namespace Facility.CodeGen.JavaScript
 											code.WriteLine("{ type: 'object', additionalProperties: false },");
 										}
 									}
+
+									code.WriteLine("'4xx': { $ref: '_error' },");
+									code.WriteLine("'5xx': { $ref: '_error' },");
 								}
 							}
 							using (code.Block("handler: async function (req, res) {", "}"))

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -861,19 +861,18 @@ namespace Facility.CodeGen.JavaScript
 								code.WriteLine();
 								using (code.Block("if (result.error) {", "}"))
 								{
-									code.WriteLine("const status = result.error.code && standardErrorCodes[result.error.code];");
-									code.WriteLine("res.status(status || 500).send(result.error);");
+									code.WriteLine("sendErrorResponse(res, result.error);");
 									code.WriteLine("return;");
 								}
 
 								code.WriteLine();
 								using (code.Block("if (result.value) {", "}"))
 								{
+									code.WriteLine("const value = result.value;");
 									if (httpMethodInfo.ResponseHeaderFields.Count != 0)
 									{
-										code.WriteLineSkipOnce();
 										foreach (var field in httpMethodInfo.ResponseHeaderFields)
-											code.WriteLine($"if (result.value.{field.ServiceField.Name} != null) res.header('{field.Name}', result.value.{field.ServiceField.Name});");
+											code.WriteLine($"if (value.{field.ServiceField.Name} != null) res.header('{field.Name}', value.{field.ServiceField.Name});");
 									}
 
 									var handledResponses = httpMethodInfo.ValidResponses.ToList();
@@ -881,39 +880,44 @@ namespace Facility.CodeGen.JavaScript
 									{
 										handledResponses.Remove(validResponse);
 										var bodyField = validResponse.BodyField!;
-										var statusCode = (int) validResponse.StatusCode;
 
 										code.WriteLineSkipOnce();
-										using (code.Block($"if (result.value.{bodyField.ServiceField.Name}) {{", "}"))
+										using (code.Block($"if (value.{bodyField.ServiceField.Name}) {{", "}"))
 										{
+											code.WriteLine($"res.status({(int) validResponse.StatusCode});");
 											var bodyFieldType = service.GetFieldType(bodyField.ServiceField)!;
-											if (bodyFieldType.Kind == ServiceTypeKind.Boolean)
+											if (bodyFieldType.Kind == ServiceTypeKind.Dto)
 											{
-												code.WriteLine($"res.status({statusCode});");
-												code.WriteLine("return;");
+												using (code.Block("res.send({", $"}}{IfTypeScript($" satisfies I{bodyField.ServiceField.TypeName}")});"))
+												{
+													// Write all properties out manually to satisfy static analyzer tools like Snyk.
+													foreach (var field in bodyFieldType.Dto!.Fields)
+														code.WriteLine($"{field.Name}: value.{bodyField.ServiceField.Name}.{field.Name},");
+												}
 											}
-											else
+											else if (bodyFieldType.Kind != ServiceTypeKind.Boolean)
 											{
-												code.WriteLine($"res.status({statusCode}).send(result.value.{bodyField.ServiceField.Name});");
-												code.WriteLine("return;");
+												code.WriteLine($"res.send(value.{bodyField.ServiceField.Name});");
 											}
+
+											code.WriteLine("return;");
 										}
 									}
 
 									if (handledResponses.Count == 1)
 									{
 										var lastValidResponse = handledResponses[0];
-										var statusCode = (int) lastValidResponse.StatusCode;
+										code.WriteLineSkipOnce();
+										code.WriteLine($"res.status({(int) lastValidResponse.StatusCode});");
 
 										if (lastValidResponse.NormalFields?.Count > 0)
 										{
-											code.WriteLineSkipOnce();
-											code.WriteLine($"res.status({statusCode}).send(result.value);");
-										}
-										else
-										{
-											code.WriteLineSkipOnce();
-											code.WriteLine($"res.status({statusCode});");
+											using (code.Block("res.send({", $"}}{IfTypeScript($" satisfies I{capMethodName}Response")});"))
+											{
+												// Write all properties out manually to satisfy static analyzer tools like Snyk.
+												foreach (var field in lastValidResponse.NormalFields)
+													code.WriteLine($"{field.ServiceField.Name}: value.{field.ServiceField.Name},");
+											}
 										}
 										code.WriteLine("return;");
 									}
@@ -937,6 +941,20 @@ namespace Facility.CodeGen.JavaScript
 
 				code.WriteLine();
 				WriteParseBooleanFunction("parseBoolean", code);
+
+				code.WriteLine();
+				using (code.Block($"function sendErrorResponse(res{IfTypeScript(": fastifyTypes.FastifyReply")}, error{IfTypeScript(": IServiceError")}) {{", "}"))
+				{
+					code.WriteLine("res.status(standardErrorCodes[error.code ?? ''] || 500);");
+					using (code.Block("res.send({", $"}}{IfTypeScript(" satisfies IServiceError")});"))
+					{
+						// Write all properties out manually to satisfy static analyzer tools like Snyk.
+						code.WriteLine("code: error.code,");
+						code.WriteLine("message: error.message,");
+						code.WriteLine("details: error.details,");
+						code.WriteLine("innerError: error.innerError,");
+					}
+				}
 
 				if (TypeScript)
 					WriteTypes(code, httpServiceInfo);

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -716,9 +716,10 @@ namespace Facility.CodeGen.JavaScript
 					using (code.Block("fastify.setErrorHandler((error, req, res) => {", "});"))
 					{
 						code.WriteLine("req.log.error(error);");
+						code.WriteLine("res.code(500);");
 						using (code.Block("if (includeErrorDetails) {", "}"))
 						{
-							code.WriteLine("res.status(500).send({");
+							code.WriteLine("res.send({");
 							using (code.Indent())
 							{
 								code.WriteLine("code: 'InternalError',");
@@ -732,7 +733,7 @@ namespace Facility.CodeGen.JavaScript
 						}
 						using (code.Block("else {", "}"))
 						{
-							code.WriteLine("res.status(500).send({");
+							code.WriteLine("res.send({");
 							using (code.Indent())
 							{
 								code.WriteLine("code: 'InternalError',");
@@ -884,7 +885,7 @@ namespace Facility.CodeGen.JavaScript
 										code.WriteLineSkipOnce();
 										using (code.Block($"if (value.{bodyField.ServiceField.Name}) {{", "}"))
 										{
-											code.WriteLine($"res.status({(int) validResponse.StatusCode});");
+											code.WriteLine($"res.code({(int) validResponse.StatusCode});");
 											var bodyFieldType = service.GetFieldType(bodyField.ServiceField)!;
 											if (bodyFieldType.Kind == ServiceTypeKind.Dto)
 											{
@@ -908,7 +909,7 @@ namespace Facility.CodeGen.JavaScript
 									{
 										var lastValidResponse = handledResponses[0];
 										code.WriteLineSkipOnce();
-										code.WriteLine($"res.status({(int) lastValidResponse.StatusCode});");
+										code.WriteLine($"res.code({(int) lastValidResponse.StatusCode});");
 
 										if (lastValidResponse.NormalFields?.Count > 0)
 										{
@@ -945,7 +946,7 @@ namespace Facility.CodeGen.JavaScript
 				code.WriteLine();
 				using (code.Block($"function sendErrorResponse(res{IfTypeScript(": fastifyTypes.FastifyReply")}, error{IfTypeScript(": IServiceError")}) {{", "}"))
 				{
-					code.WriteLine("res.status(standardErrorCodes[error.code ?? ''] || 500);");
+					code.WriteLine("res.code(standardErrorCodes[error.code ?? ''] || 500);");
 					using (code.Block("res.send({", $"}}{IfTypeScript(" satisfies IServiceError")});"))
 					{
 						// Write all properties out manually to satisfy static analyzer tools like Snyk.

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -687,7 +687,7 @@ namespace Facility.CodeGen.JavaScript
 
 						code.WriteLine();
 						WriteJsDoc(code, "Whether to make query string keys case insensitive. Defalts to false.");
-						code.WriteLine("caseInsenstiveQueryStringKeys?: boolean;");
+						code.WriteLine("caseInsensitiveQueryStringKeys?: boolean;");
 
 						code.WriteLine();
 						WriteJsDoc(code, "Whether to include error details in the response. Defaults to false.");
@@ -703,7 +703,7 @@ namespace Facility.CodeGen.JavaScript
 				WriteJsDoc(code, "EXPERIMENTAL: The generated code for this plugin is subject to change/removal without a major version bump.");
 				using (code.Block($"export const {camelCaseModuleName}Plugin" + IfTypeScript($": fastifyTypes.FastifyPluginAsync<{capModuleName}PluginOptions>") + " = async (fastify, opts) => {", "}"))
 				{
-					code.WriteLine("const { serviceOrFactory, caseInsenstiveQueryStringKeys, includeErrorDetails } = opts;");
+					code.WriteLine("const { serviceOrFactory, caseInsensitiveQueryStringKeys, includeErrorDetails } = opts;");
 
 					code.WriteLine();
 					code.WriteLine("const getService = typeof serviceOrFactory === 'function' ? serviceOrFactory : () => serviceOrFactory;");
@@ -743,7 +743,7 @@ namespace Facility.CodeGen.JavaScript
 					}
 
 					code.WriteLine();
-					using (code.Block("if (caseInsenstiveQueryStringKeys) {", "}"))
+					using (code.Block("if (caseInsensitiveQueryStringKeys) {", "}"))
 					{
 						using (code.Block("fastify.addHook('onRequest', async (req, res) => {", "});"))
 						{


### PR DESCRIPTION
- Adding `4xx` and `5xx` schemas for responses so that extra data doesn't sneak through when errors are returned from routes.
- Ensuring that object responses are written out fully so static analysis tools are happier about possible user supplied data returned to the client. This isn't really an issue in practice, so maybe not necessary?
- Misc style updates/improvements.