### PR TITLE
Refactor error and response handling in Fastify plugins

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
-    <PackageValidationBaselineVersion>3.6.0</PackageValidationBaselineVersion>
+    <VersionPrefix>3.8.0</VersionPrefix>
+    <PackageValidationBaselineVersion>3.7.0</PackageValidationBaselineVersion>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,11 @@
 
 These are the NuGet package releases. See also [npm Release Notes](ReleaseNotesNpm.md).
 
+## 3.8.0
+
+* Set explicit Content-Type headers in fastify plugin routes.
+* Revert "Send explicit return values" from 3.7.0
+
 ## 3.7.0
 
 * Add `4xx` and `5xx` response schemas to fastify plugin.

--- a/conformance/src/fastify/conformanceApiPlugin.ts
+++ b/conformance/src/fastify/conformanceApiPlugin.ts
@@ -21,28 +21,43 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
   const getService = typeof serviceOrFactory === 'function' ? serviceOrFactory : () => serviceOrFactory;
 
+  function sendErrorResponse(res: fastifyTypes.FastifyReply, error: IServiceError) {
+    const statusCode = standardErrorCodes[error.code ?? ''] || 500;
+    if (statusCode >= 500) {
+      res.log.error(error);
+      if (!includeErrorDetails) {
+        error.message = 'The service experienced an unexpected internal error.';
+        delete error.details;
+        delete error.innerError;
+      }
+    }
+
+    res.code(statusCode);
+    res.type('application/json');
+    res.send(error);
+  }
+
+  function sendResponse(res: fastifyTypes.FastifyReply, code: number, value: object | string | true) {
+    res.code(code);
+
+    if (value === true) {
+      res.send();
+    } else {
+      res.type('application/json');
+      res.send(value);
+    }
+  }
+
   for (const jsonSchema of jsonSchemas) {
     fastify.addSchema(jsonSchema);
   }
 
-  fastify.setErrorHandler((error, req, res) => {
-    req.log.error(error);
-    res.code(500);
-    if (includeErrorDetails) {
-      res.send({
-        code: 'InternalError',
-        message: error.message,
-        details: {
-          stack: error.stack?.split('\n').filter((x) => x.length > 0),
-        }
-      });
-    }
-    else {
-      res.send({
-        code: 'InternalError',
-        message: 'The service experienced an unexpected internal error.',
-      });
-    }
+  fastify.setErrorHandler((err, req, res) => {
+    sendErrorResponse(res, {
+      code: 'InternalError',
+      message: err.message,
+      details: { stack: err.stack?.split('\n').filter((x) => x.length > 0) },
+    });
   });
 
   if (caseInsensitiveQueryStringKeys) {
@@ -79,22 +94,13 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).getApiInfo(request as IGetApiInfoRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        res.send({
-          service: value.service,
-          version: value.version,
-        } satisfies IGetApiInfoResponse);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -121,21 +127,13 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).getWidgets(request as IGetWidgetsRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        res.send({
-          widgets: value.widgets,
-        } satisfies IGetWidgetsResponse);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -156,26 +154,20 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).createWidget(request as ICreateWidgetRequest);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
+      if (result.value != null && result.error == null) {
+        if (result.value.url != null) res.header('Location', result.value.url);
+        if (result.value.eTag != null) res.header('eTag', result.value.eTag);
 
-      if (result.value) {
-        const value = result.value;
-        if (value.url != null) res.header('Location', value.url);
-        if (value.eTag != null) res.header('eTag', value.eTag);
-        if (value.widget) {
-          res.code(201);
-          res.send({
-            id: value.widget.id,
-            name: value.widget.name,
-          } satisfies IWidget);
-          return;
+        if (result.value.widget) {
+          sendResponse(res, 201, result.value.widget);
+        } else {
+          throw new Error('Value must have exactly one set from: widget');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -201,30 +193,21 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).getWidget(request as IGetWidgetRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        if (result.value.eTag != null) res.header('eTag', result.value.eTag);
+
+        if (result.value.widget) {
+          sendResponse(res, 200, result.value.widget);
+        } else if (result.value.notModified) {
+          sendResponse(res, 304, result.value.notModified);
+        } else {
+          throw new Error('Value must have exactly one set from: widget, notModified');
+        }
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.eTag != null) res.header('eTag', value.eTag);
-        if (value.widget) {
-          res.code(200);
-          res.send({
-            id: value.widget.id,
-            name: value.widget.name,
-          } satisfies IWidget);
-          return;
-        }
-
-        if (value.notModified) {
-          res.code(304);
-          return;
-        }
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -251,28 +234,19 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).deleteWidget(request as IDeleteWidgetRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        if (result.value.notFound) {
+          sendResponse(res, 404, result.value.notFound);
+        } else if (result.value.conflict) {
+          sendResponse(res, 409, result.value.conflict);
+        } else {
+          sendResponse(res, 204, result.value);
+        }
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.notFound) {
-          res.code(404);
-          return;
-        }
-
-        if (value.conflict) {
-          res.code(409);
-          return;
-        }
-
-        res.code(204);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -293,21 +267,17 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).getWidgetBatch(request as IGetWidgetBatchRequest);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.results) {
-          res.code(200);
-          res.send(value.results);
-          return;
+      if (result.value != null && result.error == null) {
+        if (result.value.results) {
+          sendResponse(res, 200, result.value.results);
+        } else {
+          throw new Error('Value must have exactly one set from: results');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -336,22 +306,13 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).mirrorFields(request as IMirrorFieldsRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        res.send({
-          field: value.field,
-          matrix: value.matrix,
-        } satisfies IMirrorFieldsResponse);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -381,18 +342,13 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).checkQuery(request as ICheckQueryRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -422,18 +378,13 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).checkPath(request as ICheckPathRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -463,27 +414,23 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).mirrorHeaders(request as IMirrorHeadersRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        if (result.value.string != null) res.header('string', result.value.string);
+        if (result.value.boolean != null) res.header('boolean', result.value.boolean);
+        if (result.value.float != null) res.header('float', result.value.float);
+        if (result.value.double != null) res.header('double', result.value.double);
+        if (result.value.int32 != null) res.header('int32', result.value.int32);
+        if (result.value.int64 != null) res.header('int64', result.value.int64);
+        if (result.value.decimal != null) res.header('decimal', result.value.decimal);
+        if (result.value.enum != null) res.header('enum', result.value.enum);
+        if (result.value.datetime != null) res.header('datetime', result.value.datetime);
+
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.string != null) res.header('string', value.string);
-        if (value.boolean != null) res.header('boolean', value.boolean);
-        if (value.float != null) res.header('float', value.float);
-        if (value.double != null) res.header('double', value.double);
-        if (value.int32 != null) res.header('int32', value.int32);
-        if (value.int64 != null) res.header('int64', value.int64);
-        if (value.decimal != null) res.header('decimal', value.decimal);
-        if (value.enum != null) res.header('enum', value.enum);
-        if (value.datetime != null) res.header('datetime', value.datetime);
-        res.code(200);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -521,33 +468,21 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).mixed(request as IMixedRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        if (result.value.header != null) res.header('header', result.value.header);
+
+        if (result.value.body) {
+          sendResponse(res, 202, result.value.body);
+        } else if (result.value.empty) {
+          sendResponse(res, 204, result.value.empty);
+        } else {
+          sendResponse(res, 200, result.value);
+        }
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.header != null) res.header('header', value.header);
-        if (value.body) {
-          res.code(202);
-          res.send(value.body);
-          return;
-        }
-
-        if (value.empty) {
-          res.code(204);
-          return;
-        }
-
-        res.code(200);
-        res.send({
-          normal: value.normal,
-        } satisfies IMixedResponse);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -585,21 +520,13 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).required(request as IRequiredRequest);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        res.send({
-          normal: value.normal,
-        } satisfies IRequiredResponse);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -623,22 +550,19 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).mirrorBytes(request as IMirrorBytesRequest);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
+      if (result.value != null && result.error == null) {
+        if (result.value.type != null) res.header('Content-Type', result.value.type);
 
-      if (result.value) {
-        const value = result.value;
-        if (value.type != null) res.header('Content-Type', value.type);
-        if (value.content) {
-          res.code(200);
-          res.send(value.content);
-          return;
+        if (result.value.content) {
+          sendResponse(res, 200, result.value.content);
+        } else {
+          throw new Error('Value must have exactly one set from: content');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -662,22 +586,19 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).mirrorText(request as IMirrorTextRequest);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
+      if (result.value != null && result.error == null) {
+        if (result.value.type != null) res.header('Content-Type', result.value.type);
 
-      if (result.value) {
-        const value = result.value;
-        if (value.type != null) res.header('Content-Type', value.type);
-        if (value.content) {
-          res.code(200);
-          res.send(value.content);
-          return;
+        if (result.value.content) {
+          sendResponse(res, 200, result.value.content);
+        } else {
+          throw new Error('Value must have exactly one set from: content');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -698,21 +619,17 @@ export const conformanceApiPlugin: fastifyTypes.FastifyPluginAsync<ConformanceAp
 
       const result = await getService(req).bodyTypes(request as IBodyTypesRequest);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.content) {
-          res.code(200);
-          res.send(value.content);
-          return;
+      if (result.value != null && result.error == null) {
+        if (result.value.content) {
+          sendResponse(res, 200, result.value.content);
+        } else {
+          throw new Error('Value must have exactly one set from: content');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 }
@@ -890,16 +807,6 @@ function parseBoolean(value: string | undefined) {
     }
   }
   return undefined;
-}
-
-function sendErrorResponse(res: fastifyTypes.FastifyReply, error: IServiceError) {
-  res.code(standardErrorCodes[error.code ?? ''] || 500);
-  res.send({
-    code: error.code,
-    message: error.message,
-    details: error.details,
-    innerError: error.innerError,
-  } satisfies IServiceError);
 }
 
 /** API for a Facility test server. */

--- a/conformance/src/fastify/jsConformanceApiPlugin.js
+++ b/conformance/src/fastify/jsConformanceApiPlugin.js
@@ -8,28 +8,43 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
   const getService = typeof serviceOrFactory === 'function' ? serviceOrFactory : () => serviceOrFactory;
 
+  function sendErrorResponse(res, error) {
+    const statusCode = standardErrorCodes[error.code ?? ''] || 500;
+    if (statusCode >= 500) {
+      res.log.error(error);
+      if (!includeErrorDetails) {
+        error.message = 'The service experienced an unexpected internal error.';
+        delete error.details;
+        delete error.innerError;
+      }
+    }
+
+    res.code(statusCode);
+    res.type('application/json');
+    res.send(error);
+  }
+
+  function sendResponse(res, code, value) {
+    res.code(code);
+
+    if (value === true) {
+      res.send();
+    } else {
+      res.type('application/json');
+      res.send(value);
+    }
+  }
+
   for (const jsonSchema of jsonSchemas) {
     fastify.addSchema(jsonSchema);
   }
 
-  fastify.setErrorHandler((error, req, res) => {
-    req.log.error(error);
-    res.code(500);
-    if (includeErrorDetails) {
-      res.send({
-        code: 'InternalError',
-        message: error.message,
-        details: {
-          stack: error.stack?.split('\n').filter((x) => x.length > 0),
-        }
-      });
-    }
-    else {
-      res.send({
-        code: 'InternalError',
-        message: 'The service experienced an unexpected internal error.',
-      });
-    }
+  fastify.setErrorHandler((err, req, res) => {
+    sendErrorResponse(res, {
+      code: 'InternalError',
+      message: err.message,
+      details: { stack: err.stack?.split('\n').filter((x) => x.length > 0) },
+    });
   });
 
   if (caseInsensitiveQueryStringKeys) {
@@ -66,22 +81,13 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).getApiInfo(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        res.send({
-          service: value.service,
-          version: value.version,
-        });
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -108,21 +114,13 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).getWidgets(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        res.send({
-          widgets: value.widgets,
-        });
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -143,26 +141,20 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).createWidget(request);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
+      if (result.value != null && result.error == null) {
+        if (result.value.url != null) res.header('Location', result.value.url);
+        if (result.value.eTag != null) res.header('eTag', result.value.eTag);
 
-      if (result.value) {
-        const value = result.value;
-        if (value.url != null) res.header('Location', value.url);
-        if (value.eTag != null) res.header('eTag', value.eTag);
-        if (value.widget) {
-          res.code(201);
-          res.send({
-            id: value.widget.id,
-            name: value.widget.name,
-          });
-          return;
+        if (result.value.widget) {
+          sendResponse(res, 201, result.value.widget);
+        } else {
+          throw new Error('Value must have exactly one set from: widget');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -188,30 +180,21 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).getWidget(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        if (result.value.eTag != null) res.header('eTag', result.value.eTag);
+
+        if (result.value.widget) {
+          sendResponse(res, 200, result.value.widget);
+        } else if (result.value.notModified) {
+          sendResponse(res, 304, result.value.notModified);
+        } else {
+          throw new Error('Value must have exactly one set from: widget, notModified');
+        }
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.eTag != null) res.header('eTag', value.eTag);
-        if (value.widget) {
-          res.code(200);
-          res.send({
-            id: value.widget.id,
-            name: value.widget.name,
-          });
-          return;
-        }
-
-        if (value.notModified) {
-          res.code(304);
-          return;
-        }
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -238,28 +221,19 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).deleteWidget(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        if (result.value.notFound) {
+          sendResponse(res, 404, result.value.notFound);
+        } else if (result.value.conflict) {
+          sendResponse(res, 409, result.value.conflict);
+        } else {
+          sendResponse(res, 204, result.value);
+        }
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.notFound) {
-          res.code(404);
-          return;
-        }
-
-        if (value.conflict) {
-          res.code(409);
-          return;
-        }
-
-        res.code(204);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -280,21 +254,17 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).getWidgetBatch(request);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.results) {
-          res.code(200);
-          res.send(value.results);
-          return;
+      if (result.value != null && result.error == null) {
+        if (result.value.results) {
+          sendResponse(res, 200, result.value.results);
+        } else {
+          throw new Error('Value must have exactly one set from: results');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -323,22 +293,13 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).mirrorFields(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        res.send({
-          field: value.field,
-          matrix: value.matrix,
-        });
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -368,18 +329,13 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).checkQuery(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -409,18 +365,13 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).checkPath(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -450,27 +401,23 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).mirrorHeaders(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        if (result.value.string != null) res.header('string', result.value.string);
+        if (result.value.boolean != null) res.header('boolean', result.value.boolean);
+        if (result.value.float != null) res.header('float', result.value.float);
+        if (result.value.double != null) res.header('double', result.value.double);
+        if (result.value.int32 != null) res.header('int32', result.value.int32);
+        if (result.value.int64 != null) res.header('int64', result.value.int64);
+        if (result.value.decimal != null) res.header('decimal', result.value.decimal);
+        if (result.value.enum != null) res.header('enum', result.value.enum);
+        if (result.value.datetime != null) res.header('datetime', result.value.datetime);
+
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.string != null) res.header('string', value.string);
-        if (value.boolean != null) res.header('boolean', value.boolean);
-        if (value.float != null) res.header('float', value.float);
-        if (value.double != null) res.header('double', value.double);
-        if (value.int32 != null) res.header('int32', value.int32);
-        if (value.int64 != null) res.header('int64', value.int64);
-        if (value.decimal != null) res.header('decimal', value.decimal);
-        if (value.enum != null) res.header('enum', value.enum);
-        if (value.datetime != null) res.header('datetime', value.datetime);
-        res.code(200);
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -508,33 +455,21 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).mixed(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        if (result.value.header != null) res.header('header', result.value.header);
+
+        if (result.value.body) {
+          sendResponse(res, 202, result.value.body);
+        } else if (result.value.empty) {
+          sendResponse(res, 204, result.value.empty);
+        } else {
+          sendResponse(res, 200, result.value);
+        }
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.header != null) res.header('header', value.header);
-        if (value.body) {
-          res.code(202);
-          res.send(value.body);
-          return;
-        }
-
-        if (value.empty) {
-          res.code(204);
-          return;
-        }
-
-        res.code(200);
-        res.send({
-          normal: value.normal,
-        });
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -572,21 +507,13 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).required(request);
 
-      if (result.error) {
+      if (result.value != null && result.error == null) {
+        sendResponse(res, 200, result.value);
+      } else if (result.error != null) {
         sendErrorResponse(res, result.error);
-        return;
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      if (result.value) {
-        const value = result.value;
-        res.code(200);
-        res.send({
-          normal: value.normal,
-        });
-        return;
-      }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -610,22 +537,19 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).mirrorBytes(request);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
+      if (result.value != null && result.error == null) {
+        if (result.value.type != null) res.header('Content-Type', result.value.type);
 
-      if (result.value) {
-        const value = result.value;
-        if (value.type != null) res.header('Content-Type', value.type);
-        if (value.content) {
-          res.code(200);
-          res.send(value.content);
-          return;
+        if (result.value.content) {
+          sendResponse(res, 200, result.value.content);
+        } else {
+          throw new Error('Value must have exactly one set from: content');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -649,22 +573,19 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).mirrorText(request);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
+      if (result.value != null && result.error == null) {
+        if (result.value.type != null) res.header('Content-Type', result.value.type);
 
-      if (result.value) {
-        const value = result.value;
-        if (value.type != null) res.header('Content-Type', value.type);
-        if (value.content) {
-          res.code(200);
-          res.send(value.content);
-          return;
+        if (result.value.content) {
+          sendResponse(res, 200, result.value.content);
+        } else {
+          throw new Error('Value must have exactly one set from: content');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 
@@ -685,21 +606,17 @@ export const jsConformanceApiPlugin = async (fastify, opts) => {
 
       const result = await getService(req).bodyTypes(request);
 
-      if (result.error) {
-        sendErrorResponse(res, result.error);
-        return;
-      }
-
-      if (result.value) {
-        const value = result.value;
-        if (value.content) {
-          res.code(200);
-          res.send(value.content);
-          return;
+      if (result.value != null && result.error == null) {
+        if (result.value.content) {
+          sendResponse(res, 200, result.value.content);
+        } else {
+          throw new Error('Value must have exactly one set from: content');
         }
+      } else if (result.error != null) {
+        sendErrorResponse(res, result.error);
+      } else {
+        throw new Error('Result must have exactly one set from: value, error');
       }
-
-      throw new Error('Result must have an error or value.');
     }
   });
 }
@@ -877,14 +794,4 @@ function parseBoolean(value) {
     }
   }
   return undefined;
-}
-
-function sendErrorResponse(res, error) {
-  res.code(standardErrorCodes[error.code ?? ''] || 500);
-  res.send({
-    code: error.code,
-    message: error.message,
-    details: error.details,
-    innerError: error.innerError,
-  });
 }

--- a/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
+++ b/src/Facility.CodeGen.JavaScript/JavaScriptGenerator.cs
@@ -709,37 +709,57 @@ namespace Facility.CodeGen.JavaScript
 					code.WriteLine("const getService = typeof serviceOrFactory === 'function' ? serviceOrFactory : () => serviceOrFactory;");
 
 					code.WriteLine();
+					using (code.Block($"function sendErrorResponse(res{IfTypeScript(": fastifyTypes.FastifyReply")}, error{IfTypeScript(": IServiceError")}) {{", "}"))
+					{
+						code.WriteLine("const statusCode = standardErrorCodes[error.code ?? ''] || 500;");
+						using (code.Block("if (statusCode >= 500) {", "}"))
+						{
+							code.WriteLine("res.log.error(error);");
+							using (code.Block("if (!includeErrorDetails) {", "}"))
+							{
+								code.WriteLine("error.message = 'The service experienced an unexpected internal error.';");
+								code.WriteLine("delete error.details;");
+								code.WriteLine("delete error.innerError;");
+							}
+						}
+						code.WriteLine();
+						code.WriteLine("res.code(statusCode);");
+						code.WriteLine("res.type('application/json');");
+						code.WriteLine("res.send(error);");
+					}
+
+					code.WriteLine();
+					using (code.Block($"function sendResponse(res{IfTypeScript(": fastifyTypes.FastifyReply")}, code{IfTypeScript(": number")}, value{IfTypeScript(": object | string | true")}) {{", "}"))
+					{
+						code.WriteLine("res.code(code);");
+
+						code.WriteLine();
+						code.WriteLine("if (value === true) {");
+						using (code.Indent())
+						{
+							code.WriteLine("res.send();");
+						}
+						code.WriteLine("} else {");
+						using (code.Indent())
+						{
+							code.WriteLine("res.type('application/json');");
+							code.WriteLine("res.send(value);");
+						}
+						code.WriteLine("}");
+					}
+
+					code.WriteLine();
 					using (code.Block("for (const jsonSchema of jsonSchemas) {", "}"))
 						code.WriteLine("fastify.addSchema(jsonSchema);");
 
 					code.WriteLine();
-					using (code.Block("fastify.setErrorHandler((error, req, res) => {", "});"))
+					using (code.Block("fastify.setErrorHandler((err, req, res) => {", "});"))
 					{
-						code.WriteLine("req.log.error(error);");
-						code.WriteLine("res.code(500);");
-						using (code.Block("if (includeErrorDetails) {", "}"))
+						using (code.Block("sendErrorResponse(res, {", "});"))
 						{
-							code.WriteLine("res.send({");
-							using (code.Indent())
-							{
-								code.WriteLine("code: 'InternalError',");
-								code.WriteLine("message: error.message,");
-								using (code.Block("details: {", "}"))
-								{
-									code.WriteLine("stack: error.stack?.split('\\n').filter((x) => x.length > 0),");
-								}
-							}
-							code.WriteLine("});");
-						}
-						using (code.Block("else {", "}"))
-						{
-							code.WriteLine("res.send({");
-							using (code.Indent())
-							{
-								code.WriteLine("code: 'InternalError',");
-								code.WriteLine("message: 'The service experienced an unexpected internal error.',");
-							}
-							code.WriteLine("});");
+							code.WriteLine("code: 'InternalError',");
+							code.WriteLine("message: err.message,");
+							code.WriteLine("details: { stack: err.stack?.split('\\n').filter((x) => x.length > 0) },");
 						}
 					}
 
@@ -860,76 +880,64 @@ namespace Facility.CodeGen.JavaScript
 								code.WriteLine($"const result = await getService(req).{methodName}(request{IfTypeScript($" as I{capMethodName}Request")});");
 
 								code.WriteLine();
-								using (code.Block("if (result.error) {", "}"))
+								code.WriteLine("if (result.value != null && result.error == null) {");
+								using (code.Indent())
 								{
-									code.WriteLine("sendErrorResponse(res, result.error);");
-									code.WriteLine("return;");
-								}
-
-								code.WriteLine();
-								using (code.Block("if (result.value) {", "}"))
-								{
-									code.WriteLine("const value = result.value;");
 									if (httpMethodInfo.ResponseHeaderFields.Count != 0)
 									{
+										code.WriteLineSkipOnce();
 										foreach (var field in httpMethodInfo.ResponseHeaderFields)
-											code.WriteLine($"if (value.{field.ServiceField.Name} != null) res.header('{field.Name}', value.{field.ServiceField.Name});");
+											code.WriteLine($"if (result.value.{field.ServiceField.Name} != null) res.header('{field.Name}', result.value.{field.ServiceField.Name});");
 									}
 
-									var handledResponses = httpMethodInfo.ValidResponses.ToList();
-									foreach (var validResponse in httpMethodInfo.ValidResponses.Where(x => x.BodyField is not null))
-									{
-										handledResponses.Remove(validResponse);
-										var bodyField = validResponse.BodyField!;
+									var responsesWithoutBodyField = httpMethodInfo.ValidResponses.Where(x => x.BodyField is null).ToList();
+									var responsesWithBodyField = httpMethodInfo.ValidResponses.Where(x => x.BodyField is not null).ToList();
 
+									if (responsesWithBodyField.Count > 0)
+									{
 										code.WriteLineSkipOnce();
-										using (code.Block($"if (value.{bodyField.ServiceField.Name}) {{", "}"))
+										bool elseIf = false;
+										foreach (var response in responsesWithBodyField)
 										{
-											code.WriteLine($"res.code({(int) validResponse.StatusCode});");
-											var bodyFieldType = service.GetFieldType(bodyField.ServiceField)!;
-											if (bodyFieldType.Kind == ServiceTypeKind.Dto)
-											{
-												using (code.Block("res.send({", $"}}{IfTypeScript($" satisfies I{bodyField.ServiceField.TypeName}")});"))
-												{
-													// Write all properties out manually to satisfy static analyzer tools like Snyk.
-													foreach (var field in bodyFieldType.Dto!.Fields)
-														code.WriteLine($"{field.Name}: value.{bodyField.ServiceField.Name}.{field.Name},");
-												}
-											}
-											else if (bodyFieldType.Kind != ServiceTypeKind.Boolean)
-											{
-												code.WriteLine($"res.send(value.{bodyField.ServiceField.Name});");
-											}
+											var name = response.BodyField!.ServiceField.Name;
+											var statusCode = (int) response.StatusCode;
 
-											code.WriteLine("return;");
+											code.WriteLine($"{(elseIf ? "} else " : "")}if (result.value.{name}) {{");
+											using (code.Indent())
+												code.WriteLine($"sendResponse(res, {statusCode}, result.value.{name});");
+
+											elseIf = true;
 										}
+										code.WriteLine("} else {");
+										using (code.Indent())
+										{
+											if (responsesWithoutBodyField.Count == 1)
+												code.WriteLine($"sendResponse(res, {(int) responsesWithoutBodyField[0].StatusCode}, result.value);");
+											else
+												code.WriteLine($"throw new Error('Value must have exactly one set from: {string.Join(", ", responsesWithBodyField.Select(x => x.BodyField!.ServiceField.Name))}');");
+										}
+										code.WriteLine("}");
 									}
-
-									if (handledResponses.Count == 1)
+									else if (responsesWithoutBodyField.Count == 1)
 									{
-										var lastValidResponse = handledResponses[0];
 										code.WriteLineSkipOnce();
-										code.WriteLine($"res.code({(int) lastValidResponse.StatusCode});");
+										code.WriteLine($"sendResponse(res, {(int) responsesWithoutBodyField[0].StatusCode}, result.value);");
+									}
 
-										if (lastValidResponse.NormalFields?.Count > 0)
-										{
-											using (code.Block("res.send({", $"}}{IfTypeScript($" satisfies I{capMethodName}Response")});"))
-											{
-												// Write all properties out manually to satisfy static analyzer tools like Snyk.
-												foreach (var field in lastValidResponse.NormalFields)
-													code.WriteLine($"{field.ServiceField.Name}: value.{field.ServiceField.Name},");
-											}
-										}
-										code.WriteLine("return;");
-									}
-									else if (handledResponses.Count > 1)
-									{
-										throw new InvalidOperationException("More than one response is left.");
-									}
+									if (responsesWithoutBodyField.Count > 1)
+										throw new InvalidOperationException("Multiple responses without a body field are not supported.");
 								}
-
-								code.WriteLine();
-								code.WriteLine("throw new Error('Result must have an error or value.');");
+								code.WriteLine("} else if (result.error != null) {");
+								using (code.Indent())
+								{
+									code.WriteLine("sendErrorResponse(res, result.error);");
+								}
+								code.WriteLine("} else {");
+								using (code.Indent())
+								{
+									code.WriteLine("throw new Error('Result must have exactly one set from: value, error');");
+								}
+								code.WriteLine("}");
 							}
 						}
 					}
@@ -942,20 +950,6 @@ namespace Facility.CodeGen.JavaScript
 
 				code.WriteLine();
 				WriteParseBooleanFunction("parseBoolean", code);
-
-				code.WriteLine();
-				using (code.Block($"function sendErrorResponse(res{IfTypeScript(": fastifyTypes.FastifyReply")}, error{IfTypeScript(": IServiceError")}) {{", "}"))
-				{
-					code.WriteLine("res.code(standardErrorCodes[error.code ?? ''] || 500);");
-					using (code.Block("res.send({", $"}}{IfTypeScript(" satisfies IServiceError")});"))
-					{
-						// Write all properties out manually to satisfy static analyzer tools like Snyk.
-						code.WriteLine("code: error.code,");
-						code.WriteLine("message: error.message,");
-						code.WriteLine("details: error.details,");
-						code.WriteLine("innerError: error.innerError,");
-					}
-				}
 
 				if (TypeScript)
 					WriteTypes(code, httpServiceInfo);


### PR DESCRIPTION
- Introduced `sendResponse` and `sendErrorResponse` to simplify common cases.
- Being explicit about Content-Type header.
- Cleaned up code flow
- Cleaned up error handling and messages.

This also reverts the change that made returned values explicit from version 3.7.0. That change didn't actually improve the snyk reports. Being explicit about the Content-Type header was the trick 👍🏼 