### PR TITLE
Fix crash when response has Content-Type: application/json but empty body

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "facility-core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "facility-core",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.18",
@@ -299,7 +299,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.26.1.tgz",
       "integrity": "sha512-q7F3zSo/nU6YJpPJvQveVlIIzx9/wu75lr6oDbDzoeIRWxpoc/HQ43G4rmMoCc5my/3uSj2VEpg/D83LYZF5HQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.26.1",
         "@typescript-eslint/types": "4.26.1",
@@ -407,7 +406,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -878,7 +876,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
       "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
@@ -1901,7 +1898,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
       "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -2360,7 +2356,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
       "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2808,7 +2803,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.26.1.tgz",
       "integrity": "sha512-q7F3zSo/nU6YJpPJvQveVlIIzx9/wu75lr6oDbDzoeIRWxpoc/HQ43G4rmMoCc5my/3uSj2VEpg/D83LYZF5HQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "4.26.1",
         "@typescript-eslint/types": "4.26.1",
@@ -2867,8 +2861,7 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.1",
@@ -3215,7 +3208,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
       "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
@@ -3978,8 +3970,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
       "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -4280,8 +4271,7 @@
       "version": "3.9.9",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
       "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/ts/src/facilityCore.ts
+++ b/ts/src/facilityCore.ts
@@ -108,7 +108,8 @@ export namespace HttpClientUtility {
 				throw new TypeError('fetch must resolve Promise with { status, headers, json() }.');
 			}
 			const contentType = response.headers.get('content-type');
-			if (!contentType) {
+			const contentLength = response.headers.get('content-length');
+			if (!contentType || contentLength === '0') {
 				return Promise.resolve({ response: response, json: {} });
 			}
 			if (contentType.toLowerCase().substr(0, jsonContentType.length) === jsonContentType) {

--- a/ts/test/fetchResponse.ts
+++ b/ts/test/fetchResponse.ts
@@ -1,0 +1,66 @@
+import { HttpClientUtility } from '../src/facilityCore';
+import { expect, should } from 'chai';
+
+should();
+
+const fetchResponse = HttpClientUtility.fetchResponse;
+
+describe('fetchResponse', () => {
+
+	it('should handle json content-type with content-length 0', async () => {
+		const mockFetch: HttpClientUtility.IFetch = () => Promise.resolve({
+			status: 202,
+			headers: {
+				get(name: string) {
+					if (name === 'content-type') return 'application/json';
+					if (name === 'content-length') return '0';
+					return null;
+				},
+			},
+			json() {
+				return Promise.reject(new SyntaxError('Unexpected end of JSON input'));
+			},
+		});
+
+		const result = await fetchResponse(mockFetch, 'http://example.com', {});
+		expect(result.response.status).to.equal(202);
+		expect(result.json).to.deep.equal({});
+	});
+
+	it('should parse json when content-type is json and body is present', async () => {
+		const mockFetch: HttpClientUtility.IFetch = () => Promise.resolve({
+			status: 200,
+			headers: {
+				get(name: string) {
+					if (name === 'content-type') return 'application/json';
+					if (name === 'content-length') return '15';
+					return null;
+				},
+			},
+			json() {
+				return Promise.resolve({ value: 'ok' });
+			},
+		});
+
+		const result = await fetchResponse(mockFetch, 'http://example.com', {});
+		expect(result.response.status).to.equal(200);
+		expect(result.json).to.deep.equal({ value: 'ok' });
+	});
+
+	it('should return empty json when no content-type header', async () => {
+		const mockFetch: HttpClientUtility.IFetch = () => Promise.resolve({
+			status: 204,
+			headers: {
+				get() { return null; },
+			},
+			json() {
+				return Promise.reject(new Error('should not be called'));
+			},
+		});
+
+		const result = await fetchResponse(mockFetch, 'http://example.com', {});
+		expect(result.response.status).to.equal(204);
+		expect(result.json).to.deep.equal({});
+	});
+
+});


### PR DESCRIPTION


When a server returns a response like '202 Accepted' with Content-Type: application/json and Content-Length: 0, the client would call response.json() on the empty body, causing a JSON parse error (SyntaxError). This crashed FSD clients that tried to deserialize the resulting undefined/null.

Fix: check Content-Length header before attempting JSON deserialization. If Content-Length is '0', skip parsing and return an empty object, matching the existing behavior for missing Content-Type.